### PR TITLE
chore: use pre-commit/mirrors-clang-format instead

### DIFF
--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
 
 {%- if  cookiecutter.project_type == "pybind11" %}
 
-- repo: https://github.com/ssciwr/clang-format-hook
+- repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v13.0.0
   hooks:
    - id: clang-format


### PR DESCRIPTION
The original repository is being deprecated in favor of the automatically maintained https://github.com/pre-commit/mirrors-clang-format. See https://github.com/ssciwr/clang-format-hook.