### PR TITLE
readthedocs.yml: python version should be a string

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ sphinx:
 formats: all
 
 python:
-  version: 3.8
+  version: "3.8"
   install:
   - method: pip
     path: .


### PR DESCRIPTION
Python version should be string, see https://docs.readthedocs.io/en/stable/config-file/v2.html#python-version-legacy
