### PR TITLE
Fixing issue #50: syncing black-jupyter and isort tools

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject-flit.toml
+++ b/{{cookiecutter.project_name}}/pyproject-flit.toml
@@ -77,3 +77,6 @@ warn_unused_ignores = true
 warn_return_any = true
 no_implicit_reexport = true
 strict_equality = true
+
+[tool.isort]
+profile = "black"

--- a/{{cookiecutter.project_name}}/pyproject-flit621,trampolim,whey.toml
+++ b/{{cookiecutter.project_name}}/pyproject-flit621,trampolim,whey.toml
@@ -109,3 +109,6 @@ warn_unused_ignores = true
 warn_return_any = true
 no_implicit_reexport = true
 strict_equality = true
+
+[tool.isort]
+profile = "black"

--- a/{{cookiecutter.project_name}}/pyproject-poetry.toml
+++ b/{{cookiecutter.project_name}}/pyproject-poetry.toml
@@ -76,3 +76,6 @@ warn_unused_ignores = true
 warn_return_any = true
 no_implicit_reexport = true
 strict_equality = true
+
+[tool.isort]
+profile = "black"

--- a/{{cookiecutter.project_name}}/pyproject-pybind11.toml
+++ b/{{cookiecutter.project_name}}/pyproject-pybind11.toml
@@ -55,3 +55,6 @@ ignore = [
     "src/*/_version.py",
     "noxfile.py",
 ]
+
+[tool.isort]
+profile = "black"

--- a/{{cookiecutter.project_name}}/pyproject-setuptools.toml
+++ b/{{cookiecutter.project_name}}/pyproject-setuptools.toml
@@ -46,3 +46,6 @@ ignore = [
     "src/*/_version.py",
     "noxfile.py",
 ]
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
Fixes #50.

Added

```toml
[tool.isort]
profile = "black"
```

To all `pyproject` templates.