### PR TITLE
feat: add basic structure for a CITATION.cff file

### DIFF
--- a/{{cookiecutter.project_name}}/CITATION.cff
+++ b/{{cookiecutter.project_name}}/CITATION.cff
@@ -1,0 +1,15 @@
+cff-version: 1.2.0
+message: "Please cite the following works when using this software."
+type: software
+title: {{cookiecutter.project_name}}
+abstract: {{ cookiecutter.project_short_description }}
+authors:
+- family-names:
+  given-names:
+  orcid:
+  affiliation:
+doi:
+repository-code:
+url: {{ cookiecutter.url }}
+keywords:
+license: {{ cookiecutter.license }}

--- a/{{cookiecutter.project_name}}/MANIFEST-setuptools,pybind11,skbuild.in
+++ b/{{cookiecutter.project_name}}/MANIFEST-setuptools,pybind11,skbuild.in
@@ -1,7 +1,7 @@
 graft src
 graft tests
 
-include LICENSE README.md pyproject.toml setup.py setup.cfg
+include LICENSE README.md pyproject.toml setup.py setup.cfg CITATION.cff
 global-exclude __pycache__ *.py[cod] .*
 {%- if cookiecutter.project_type == "skbuild" %}
 include CMakeLists.txt


### PR DESCRIPTION
Add a template for CITATION.cff file, some changes can be made to complete the file during setup:
- Ask for ORCID and Affiliation
- Separate Family Name and Given Name
- Ask for keywords
- Provision for multiple authors

File format referred from [hist/CITATION.cff](https://github.com/scikit-hep/hist/blob/b368cb904c6be7a411200d023bafc8ad47ad4c4a/CITATION.cff), I believe that currently Nox is failing a few tests.