### PR TITLE
refactor: use backend instead of project_type

### DIFF
--- a/.github/workflows/reusable-cookie.yml
+++ b/.github/workflows/reusable-cookie.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.11", "3.12-dev"]
+        python-version: ["3.7", "3.12"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
         include:
@@ -68,6 +68,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install nox
         run: pip install nox

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,7 +3,7 @@
   "org": "org",
   "url": "https://github.com/{{ cookiecutter.org }}/{{ cookiecutter.project_name }}",
   "full_name": "My Name",
-  "project_type": [
+  "backend": [
     "hatch",
     "setuptools",
     "setuptools621",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 project_name = "{{ cookiecutter.project_name }}"
-project_type = "{{ cookiecutter.project_type }}"
-project_types = {
+backend = "{{ cookiecutter.backend }}"
+backends = {
     "setuptools",
     "pybind11",
     "skbuild",
@@ -16,17 +16,17 @@ project_types = {
     "hatch",
     "setuptools621",
 }
-other_project_types = project_types - {project_type}
+other_backends = backends - {backend}
 
 files = (p for p in Path(".").rglob("*") if p.is_file() and "-" in p.stem)
 
 for f in files:
     base, current = f.stem.rsplit("-", 1)
     currents = set(current.split(","))
-    if project_type in currents:
+    if backend in currents:
         # with_stem requires python 3.9
         f.replace(f.with_name(f"{base}{f.suffix}"))
-    elif currents & other_project_types:
+    elif currents & other_backends:
         f.unlink()
 
 files = (p for p in Path(".").rglob("*") if p.is_file() and "^" in p.stem)
@@ -34,7 +34,7 @@ files = (p for p in Path(".").rglob("*") if p.is_file() and "^" in p.stem)
 for f in files:
     base, current = f.stem.rsplit("^", 1)
     currents = set(current.split(","))
-    if project_type in currents:
+    if backend in currents:
         f.unlink()
     else:
         # with_stem requires python 3.9

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,12 +19,12 @@ nox.needs_version = ">=2022.1.7"
 
 DIR = Path(__file__).parent.resolve()
 with DIR.joinpath("cookiecutter.json").open() as f:
-    BACKENDS = json.load(f)["project_type"]
+    BACKENDS = json.load(f)["backend"]
 
 JOB_FILE = """\
 default_context:
   project_name: cookie-{backend}
-  project_type: {backend}
+  backend: {backend}
 """
 
 nox.options.sessions = ["lint", "tests", "native"]

--- a/{{cookiecutter.project_name}}/.github/CONTRIBUTING.md
+++ b/{{cookiecutter.project_name}}/.github/CONTRIBUTING.md
@@ -30,7 +30,7 @@ environment for each run.
 
 You can set up a development environment by running:
 
-{% if cookiecutter.project_type == "poetry" -%}
+{% if cookiecutter.backend == "poetry" -%}
 
 ```bash
 poetry install

--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-{%- set compiled = cookiecutter.project_type in ["pybind11", "maturin", "skbuild", "mesonpy"] -%}
+{%- set compiled = cookiecutter.backend in ["pybind11", "maturin", "skbuild", "mesonpy"] -%}
 name: CI
 
 on:
@@ -64,7 +64,7 @@ jobs:
         with:
           python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
 
-      {%- if cookiecutter.project_type == "mesonpy" %}
+      {%- if cookiecutter.backend == "mesonpy" %}
       - name: Activate MSVC for Meson
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
@@ -100,7 +100,7 @@ jobs:
         with:
           path: dist
 
-      {%- if cookiecutter.project_type != "trampolim" %}
+      {%- if cookiecutter.backend != "trampolim" %}
 
       - name: Check products
         run: pipx run twine check dist/*
@@ -128,7 +128,7 @@ jobs:
           # Remember to tell (test-)pypi about this repo before publishing
           # Remove this line to publish to PyPI
           repository-url: https://test.pypi.org/legacy/
-          {%- if cookiecutter.project_type == "trampolim" %}
+          {%- if cookiecutter.backend == "trampolim" %}
           # Check not supported currently by twine + trampolim
           verify-metadata: false
           {%- endif %}

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: ruff
         args: ["--fix", "--show-fixes"]
 
-{%- if cookiecutter.project_type == "setuptools" or cookiecutter.project_type == "pybind11" %}
+{%- if cookiecutter.backend == "setuptools" or cookiecutter.backend == "pybind11" %}
 
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: "v2.2.0"
@@ -60,7 +60,7 @@ repos:
 
 {%- endif %}
 
-{%- if cookiecutter.project_type in ["pybind11", "skbuild", "mesonpy"] %}
+{%- if cookiecutter.backend in ["pybind11", "skbuild", "mesonpy"] %}
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: "v16.0.2"
@@ -97,7 +97,7 @@ repos:
         entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
         exclude: .pre-commit-config.yaml
 
-{%- if cookiecutter.project_type in ["setuptools", "pybind11"] %}
+{%- if cookiecutter.backend in ["setuptools", "pybind11"] %}
 
   - repo: https://github.com/mgedmin/check-manifest
     rev: "0.49"
@@ -106,7 +106,7 @@ repos:
         stages: [manual]
 {%- endif %}
 
-{%- if cookiecutter.project_type == "skbuild" %}
+{%- if cookiecutter.backend == "skbuild" %}
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: "v0.6.13"

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import argparse
-{%- if cookiecutter.project_type != "pybind11" %}
+{%- if cookiecutter.backend != "pybind11" %}
 import shutil
 from pathlib import Path
 {%- endif %}
 
 import nox
 
-{% if cookiecutter.project_type != "pybind11" -%}
+{% if cookiecutter.backend != "pybind11" -%}
 DIR = Path(__file__).parent.resolve()
 
 {% endif -%}
@@ -83,7 +83,7 @@ def build_api_docs(session: nox.Session) -> None:
     )
 
 
-{%- if cookiecutter.project_type != "pybind11" %}
+{%- if cookiecutter.backend != "pybind11" %}
 
 
 @nox.session

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -1,43 +1,43 @@
 [build-system]
-{%- if cookiecutter.project_type == "trampolim" %}
+{%- if cookiecutter.backend == "trampolim" %}
 requires = ["trampolim>=0.1.0"]
 build-backend = "trampolim"
-{%- elif cookiecutter.project_type == "whey" %}
+{%- elif cookiecutter.backend == "whey" %}
 requires = ["whey>=0.0.17"]
 build-backend = "whey"
-{%- elif cookiecutter.project_type == "pdm" %}
+{%- elif cookiecutter.backend == "pdm" %}
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"
-{%- elif cookiecutter.project_type == "maturin" %}
+{%- elif cookiecutter.backend == "maturin" %}
 requires = ["maturin>=0.12,<0.15"]
 build-backend = "maturin"
-{%- elif cookiecutter.project_type == "hatch" %}
+{%- elif cookiecutter.backend == "hatch" %}
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-{%- elif cookiecutter.project_type == "setuptools621" %}
+{%- elif cookiecutter.backend == "setuptools621" %}
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
-{%- elif cookiecutter.project_type == "flit" %}
+{%- elif cookiecutter.backend == "flit" %}
 requires = ["flit_core >=3.4"]
 build-backend = "flit_core.buildapi"
-{%- elif cookiecutter.project_type == "setuptools" %}
+{%- elif cookiecutter.backend == "setuptools" %}
 requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
-{%- elif cookiecutter.project_type == "pybind11" %}
+{%- elif cookiecutter.backend == "pybind11" %}
 requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "pybind11"]
 build-backend = "setuptools.build_meta"
-{%- elif cookiecutter.project_type == "skbuild"  %}
+{%- elif cookiecutter.backend == "skbuild"  %}
 requires = ["pybind11", "scikit-build-core"]
 build-backend = "scikit_build_core.build"
-{%- elif cookiecutter.project_type == "mesonpy"  %}
+{%- elif cookiecutter.backend == "mesonpy"  %}
 requires = ["pybind11", "meson-python"]
 build-backend = "mesonpy"
-{%- elif cookiecutter.project_type == "poetry" %}
+{%- elif cookiecutter.backend == "poetry" %}
 requires = ["poetry_core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 {%- endif %}
 
-{%- if cookiecutter.project_type in ["setuptools", "pybind11"] %}
+{%- if cookiecutter.backend in ["setuptools", "pybind11"] %}
 
 
 [tool.setuptools_scm]
@@ -54,7 +54,7 @@ ignore = [
   "noxfile.py",
 ]
 
-{%- elif cookiecutter.project_type == "poetry" %}
+{%- elif cookiecutter.backend == "poetry" %}
 
 
 [tool.poetry]
@@ -120,7 +120,7 @@ docs = [
 
 [project]
 name = "{{ cookiecutter.project_name }}"
-{%- if cookiecutter.project_type not in ["trampolim", "flit", "hatch"] %}
+{%- if cookiecutter.backend not in ["trampolim", "flit", "hatch"] %}
 version = "0.1.0"
 {%- endif %}
 authors = [
@@ -158,7 +158,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-{%- if cookiecutter.project_type in ["trampolim", "flit", "hatch"] %}
+{%- if cookiecutter.backend in ["trampolim", "flit", "hatch"] %}
 dynamic = ["version"]
 {%- endif %}
 dependencies = [
@@ -190,24 +190,24 @@ Changelog = "{{ cookiecutter.url }}/releases"
 {%- endif %}
 
 
-{%- if cookiecutter.project_type == "skbuild" %}
+{%- if cookiecutter.backend == "skbuild" %}
 [tool.scikit-build]
 minimum-version = "0.2"
 build-dir = "build/{cache_tag}"
-{%- elif cookiecutter.project_type == "whey" %}
+{%- elif cookiecutter.backend == "whey" %}
 [tool.whey]
 source-dir = "src"
-{%- elif cookiecutter.project_type == "trampolim" %}
+{%- elif cookiecutter.backend == "trampolim" %}
 [tool.trampolim]
 module-location = "src"
-{%- elif cookiecutter.project_type == "hatch" %}
+{%- elif cookiecutter.backend == "hatch" %}
 [tool.hatch]
 version.path = "src/{{ cookiecutter.__project_slug  }}/__init__.py"
 envs.default.dependencies = [
   "pytest",
   "pytest-cov",
 ]
-{%- elif cookiecutter.project_type == "pdm" %}
+{%- elif cookiecutter.backend == "pdm" %}
 [tool.pdm.dev-dependencies]
 devtest = ["pytest", "pytest-cov"]
 {%- endif %}

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/__init__.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/__init__.py
@@ -7,7 +7,7 @@ Copyright (c) {{ cookiecutter.year }} {{ cookiecutter.full_name }}. All rights r
 
 from __future__ import annotations
 
-{% if cookiecutter.project_type == "setuptools" or cookiecutter.project_type == "pybind11" -%}
+{% if cookiecutter.backend == "setuptools" or cookiecutter.backend == "pybind11" -%}
 from ._version import version as __version__
 {%- else -%}
 __version__ = "0.1.0"


### PR DESCRIPTION
This is how the README already refers to it, and it's fewer characters for the thing that's coming next.


- ci: use pre-releases for 3.12 instead of dev
- refactor: use backend instead of project_type
