### PR TITLE
chore: drop Python 3.7

### DIFF
--- a/.github/workflows/reusable-cookie.yml
+++ b/.github/workflows/reusable-cookie.yml
@@ -55,11 +55,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.12"]
+        python-version: ["3.8", "3.12"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
         include:
-          - python-version: pypy-3.8
+          - python-version: pypy-3.9
             runs-on: ubuntu-latest
 
     steps:
@@ -110,7 +110,6 @@ jobs:
         run: nox -s 'native(poetry)'
 
       - name: Native pdm tooling
-        if: matrix.python-version != 'pypy-3.7'
         run: nox -s 'native(pdm)'
 
       - name: Activate MSVC for Meson

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ During generation you can select from the following backends for your package:
    all-in-one. Makes some bad default assumptions for libraries. The only one
    with a non-standard pyproject.toml config.
 7. [setuptools621][setuptools]: The classic build system, but with the new
-   standardized configuration. Python 3.7+.
+   standardized configuration.
 8. [setuptools][]: The classic build system. Most powerful, but high learning
    curve and lots of configuration required.
 9. [pybind11][]: This is setuptools but with an C++ extension written in
@@ -102,7 +102,7 @@ Check the key setup files, `pyproject.toml`, and possibly `setup.cfg` and
 `setup.py` (pybind11 example). Update README.md. Also update and add docs to
 `docs/`.
 
-There are a few example dependencies and a minimum Python version of 3.7, feel
+There are a few example dependencies and a minimum Python version of 3.8, feel
 free to change it to whatever you actually need/want.
 
 #### Contained components:

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -88,9 +88,9 @@ tests:
     fail-fast: false
     matrix:
       python-version:
-        - "3.7"
+        - "3.8"
         - "3.11"
-        - "3.12-dev"
+        - "3.12"
   name: Check Python ${{ matrix.python-version }}
   steps:
     - uses: actions/checkout@v3
@@ -101,6 +101,7 @@ tests:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Install package
       run: python -m pip install -e .[test]

--- a/docs/pages/guides/mypy.md
+++ b/docs/pages/guides/mypy.md
@@ -127,7 +127,7 @@ Protocols - formalized duck-typing, basically. This allows cross library
 interoperability, unlike traditional inheritance. Here’s how it works:
 
 ```python
-from typing import Protocol  # or typing_extensions for < 3.8
+from typing import Protocol
 
 
 class Duck(Protocol):

--- a/docs/pages/guides/packaging_classic.md
+++ b/docs/pages/guides/packaging_classic.md
@@ -217,8 +217,8 @@ And `.gitattributes` (or add this line if you are already using this file):
 ```
 
 This will allow git archives (including the ones generated from GitHub) to also
-support versioning. This will only work with `setuptools_scm>=7`, which requires
-Python 3.7+ (though adding the files won't hurt older versions).
+support versioning. This will only work with `setuptools_scm>=7` (though adding
+the files won't hurt older versions).
 
 ### Classic in-source versioning
 
@@ -276,7 +276,6 @@ classifiers =
     Programming Language :: C++
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -299,7 +298,7 @@ project_urls =
 packages = find:
 install_requires =
     numpy>=1.13.3
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = True
 package_dir =
     =src

--- a/docs/pages/guides/packaging_simple.md
+++ b/docs/pages/guides/packaging_simple.md
@@ -92,7 +92,7 @@ authors = [
 maintainers = [
   { name = "My Organization", email = "myemail@email.com" },
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 dependencies = [
   "numpy>=1.13.3",
@@ -102,7 +102,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/docs/pages/guides/pytest.md
+++ b/docs/pages/guides/pytest.md
@@ -134,11 +134,10 @@ If a test fails, you have lots of options to save time in debugging. Adding
 be added by default, see above). You can run `pytest` with `--pdb`, which will
 drop you into a debugger on each failure. Or you can use `--trace` which will
 drop you into a debugger at the start of each test selected (so probably use the
-selection methods above). `pytest` also supports `breakpoint()` in Python 3.7+.
-You can also start out in your debugger at the beginning of the last failed test
-with `--trace --lf`.
-[See the docs](https://docs.pytest.org/en/stable/usage.html) for more running
-tips.
+selection methods above). `pytest` also supports `breakpoint()`. You can also
+start out in your debugger at the beginning of the last failed test with
+`--trace --lf`. [See the docs](https://docs.pytest.org/en/stable/usage.html) for
+more running tips.
 
 ## Guidelines for writing good tests
 
@@ -280,13 +279,13 @@ pytest to run a group of marked tests. This is an expression; you can use
 Probably the most useful built-in mark is `skipif`:
 
 ```python
-@pytest.mark.skipif("sys.version_info >= (3, 7)")
-def test_only_on_37plus():
+@pytest.mark.skipif("sys.version_info >= (3, 8)")
+def test_only_on_38plus():
     x = 3
     assert f"{x = }" == "x = 3"
 ```
 
-Now this test will only run on Python 3.7 or newer, and will be skipped on
+Now this test will only run on Python 3.8 or newer, and will be skipped on
 earlier versions. You don't have to use a string for the condition, but if you
 don't, add a `reason=` so there will still be a nice printout explaining why the
 test was skipped.

--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -204,7 +204,7 @@ extend-ignore = [
   "E501",   # Line too long
   "PT004",  # Use underscore for non-returning fixture (use usefixture instead)
 ]
-target-version = "py37"
+target-version = "py38"
 typing-modules = ["mypackage._compat.typing"]
 src = ["src"]
 unfixable = [
@@ -430,15 +430,15 @@ when clearly better (please always use them, they are faster) if you set
   rev: "v3.7.0"
   hooks:
     - id: pyupgrade
-      args: ["--py37-plus"]
+      args: ["--py38-plus"]
 ```
 
 [pyupgrade]: https://github.com/asottile/pyupgrade:
 
 > <h4 class="no_toc">Note:</h4>
 >
-> If you set this to `--py37-plus`, you can add the annotations import by adding
-> the following line to your isort pre-commit hook configuration:
+> If you set this to at least `--py37-plus`, you can add the annotations import
+> by adding the following line to your isort pre-commit hook configuration:
 >
 > ```yaml
 > args: ["-a", "from __future__ import annotations"]
@@ -494,7 +494,7 @@ that looks like this:
 ```ini
 [tool.mypy]
 files = "src"
-python_version = "3.7"
+python_version = "3.8"
 strict = true
 show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
@@ -742,7 +742,7 @@ check than Flake8. Here is a suggested pyproject.toml entry to get you started:
 
 ```toml
 [tool.pylint]
-py-version = "3.7"
+py-version = "3.8"
 jobs = "0"
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"

--- a/docs/pages/guides/tasks.md
+++ b/docs/pages/guides/tasks.md
@@ -71,8 +71,7 @@ of Python prepared for you, then use this input:
 ```yaml
 - uses: wntrblm/nox@2022.8.7
   with:
-    python-versions:
-      "3.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy-3.8, pypy-3.9-nightly"
+    python-versions: "3.8, 3.9, 3.10, 3.11, 3.12, pypy-3.9, pypy-3.10-nightly"
 ```
 
 ### Introduction
@@ -130,7 +129,7 @@ You can parametrize sessions. either on Python or on any other item.
 
 ```python
 # Shortcut to parametrize Python
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"])
 def my_session(session: nox.Session) -> None:
     ...
 

--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -48,11 +48,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.11", "3.12-dev"]
+        python-version: ["3.8", "3.11", "3.12"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
         include:
-          - python-version: pypy-3.8
+          - python-version: pypy-3.9
             runs-on: ubuntu-latest
 
     steps:
@@ -63,6 +63,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
+          allow-prereleases: true
 
       {%- if cookiecutter.backend == "mesonpy" %}
       - name: Activate MSVC for Meson

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
     rev: "v2.2.0"
     hooks:
       - id: setup-cfg-fmt
-        args: [--include-version-classifiers, --max-py-version=3.11]
+        args: [--include-version-classifiers, --max-py-version=3.12]
 
 {%- endif %}
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -90,8 +90,8 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7"
-typing_extensions = { version = ">=3.7", python = "<3.8" }
+python = ">=3.8"
+typing_extensions = { version = ">=4.6", python = "<3.11" }
 
 furo = { version = ">=22", optional = true }
 myst_parser = { version = ">=0.13", optional = true }
@@ -133,7 +133,7 @@ maintainers = [
 {%- endif %}
 description = "{{ cookiecutter.project_short_description }}"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 1 - Planning",
   "Intended Audience :: Science/Research",
@@ -149,7 +149,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -162,7 +161,7 @@ classifiers = [
 dynamic = ["version"]
 {%- endif %}
 dependencies = [
-  "typing_extensions >=3.7; python_version<'3.8'",
+  "typing_extensions >=4.6; python_version<'3.11'",
 ]
 
 [project.optional-dependencies]
@@ -237,7 +236,7 @@ port.exclude_lines = [
 
 [tool.mypy]
 files = ["src", "tests"]
-python_version = "3.7"
+python_version = "3.8"
 warn_unused_configs = true
 strict = true
 show_error_codes = true
@@ -282,7 +281,7 @@ extend-ignore = [
   "PLR",    # Design related pylint codes
   "E501",   # Line too long
 ]
-target-version = "py37"
+target-version = "py38"
 typing-modules = ["{{ cookiecutter.__project_slug }}._compat.typing"]
 src = ["src"]
 unfixable = [
@@ -299,7 +298,7 @@ isort.required-imports = ["from __future__ import annotations"]
 
 
 [tool.pylint]
-py-version = "3.7"
+py-version = "3.8"
 ignore-paths= ["src/{{ cookiecutter.__project_slug }}/_version.py"]
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/_compat/typing.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/_compat/typing.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 
 import sys
 
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal, Protocol, runtime_checkable
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeAlias
 else:
-    from typing import Literal, Protocol, runtime_checkable
+    from typing import TypeAlias
 
-__all__ = ["Protocol", "runtime_checkable", "Literal"]
+if sys.version_info < (3, 11):
+    from typing_extensions import Self, assert_never
+else:
+    from typing import Self, assert_never
+
+__all__ = ["TypeAlias", "Self", "assert_never"]
 
 
 def __dir__() -> list[str]:

--- a/{{cookiecutter.project_name}}/tests/test_package.py
+++ b/{{cookiecutter.project_name}}/tests/test_package.py
@@ -1,23 +1,14 @@
 from __future__ import annotations
 
 import {{ cookiecutter.__project_slug }} as m
-from {{ cookiecutter.__project_slug }}._compat.typing import Protocol, runtime_checkable
+import {{ cookiecutter.__project_slug }}._compat.typing as typing_backports
 
 
 def test_version():
     assert m.__version__
 
 
-@runtime_checkable
-class HasQuack(Protocol):
-    def quack(self) -> str:
-        ...
-
-
-class Duck:
-    def quack(self) -> str:
-        return "quack"
-
-
 def test_has_typing():
-    assert isinstance(Duck(), HasQuack)
+    assert hasattr(typing_backports, "TypeAlias")
+    assert hasattr(typing_backports, "Self")
+    assert hasattr(typing_backports, "assert_never")

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.backend in ['setuptools','pybind11'] %}setup.cfg{% endif %}
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.backend in ['setuptools','pybind11'] %}setup.cfg{% endif %}
@@ -29,11 +29,11 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Scientific/Engineering
     Typing :: Typed
 project_urls =
@@ -45,8 +45,8 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    typing-extensions>=3.7;python_version<'3.8'
-python_requires = >=3.7
+    typing-extensions>=4.6;python_version<'3.11'
+python_requires = >=3.8
 include_package_data = True
 package_dir =
     =src

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.backend=='maturin' %}Cargo.toml{% endif %}
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.backend=='maturin' %}Cargo.toml{% endif %}
@@ -19,5 +19,5 @@ rand = "0.8.3"
 [dependencies.pyo3]
 version = "0.18.1"
 # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
-# "abi3-py37" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.7
-features = ["extension-module", "abi3-py37"]
+# "abi3-py38" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.8
+features = ["extension-module", "abi3-py38"]


### PR DESCRIPTION
~~Tomorrow~~ Today 3.7 is EoL.

I've added some <3.11 examples to the typing backports, since we don't have <3.8 ones anymore. We could fill it out in the future.
