### PR TITLE
chore: use released version of pages in sp-repo-review

### DIFF
--- a/src/sp_repo_review/checks/__init__.py
+++ b/src/sp_repo_review/checks/__init__.py
@@ -2,6 +2,4 @@ from __future__ import annotations
 
 
 def mk_url(page: str) -> str:
-    # Update to this after the next sync
-    # return f"https://learn.scientific-python.org/development/guides/{page}#{{name}}"
-    return f"https://scientific-python-cookie.readthedocs.io/en/latest/guides/{page}#{{name}}"
+    return f"https://learn.scientific-python.org/development/guides/{page}#{{name}}"


### PR DESCRIPTION
Now that the badges are released, we can link to them.
