### PR TITLE
fix: badge links

### DIFF
--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -8,8 +8,7 @@
 [![PyPI platforms][pypi-platforms]][pypi-link]
 
 [![GitHub Discussion][github-discussions-badge]][github-discussions-link]
-[![Gitter][gitter-badge]][gitter-link]
-{%- if cookiecutter.org == "Scikit-HEP" %}
+{%- if cookiecutter.org | lower == "scikit-hep" %}
 [![Scikit-HEP][sk-badge]](https://scikit-hep.org/)
 {%- endif %}
 
@@ -20,14 +19,12 @@
 [conda-link]:               https://github.com/conda-forge/{{cookiecutter.project_name}}-feedstock
 [github-discussions-badge]: https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github
 [github-discussions-link]:  {{cookiecutter.url}}/discussions
-[gitter-badge]:             https://badges.gitter.im/{{cookiecutter.url}}/community.svg
-[gitter-link]:              https://gitter.im/{{cookiecutter.url}}/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
 [pypi-link]:                https://pypi.org/project/{{cookiecutter.project_name}}/
 [pypi-platforms]:           https://img.shields.io/pypi/pyversions/{{cookiecutter.project_name}}
 [pypi-version]:             https://img.shields.io/pypi/v/{{cookiecutter.project_name}}
 [rtd-badge]:                https://readthedocs.org/projects/{{cookiecutter.project_name}}/badge/?version=latest
 [rtd-link]:                 https://{{cookiecutter.project_name}}.readthedocs.io/en/latest/?badge=latest
-{%- if cookiecutter.org == "Scikit-HEP" %}
+{%- if cookiecutter.org | lower == "scikit-hep" %}
 [sk-badge]:                 https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg
 {%- endif %}
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -63,7 +63,7 @@ version = "0.1.0"
 authors = [
   "{{ cookiecutter.full_name }} <{{ cookiecutter.email }}>",
 ]
-{%- if cookiecutter.org == "Scikit-HEP" %}
+{%- if cookiecutter.org == "scikit-hep" %}
 maintainers = [
   "The Scikit-HEP admins <scikit-hep-admins@googlegroups.com>",
 ]
@@ -126,7 +126,7 @@ version = "0.1.0"
 authors = [
   { name = "{{ cookiecutter.full_name }}", email = "{{ cookiecutter.email }}" },
 ]
-{%- if cookiecutter.org == "Scikit-HEP" %}
+{%- if cookiecutter.org | lower == "scikit-hep" %}
 maintainers = [
   { name = "The Scikit-HEP admins", email = "scikit-hep-admins@googlegroups.com" },
 ]

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.backend in ['setuptools','pybind11'] %}setup.cfg{% endif %}
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.backend in ['setuptools','pybind11'] %}setup.cfg{% endif %}
@@ -6,7 +6,7 @@ long_description_content_type = text/markdown
 url = {{ cookiecutter.url }}
 author = {{ cookiecutter.full_name }}
 author_email = {{ cookiecutter.email }}
-{%- if cookiecutter.org == "Scikit-HEP" %}
+{%- if cookiecutter.org | lower == "scikit-hep" %}
 maintainer = The Scikit-HEP admins
 maintainer_email = scikit-hep-admins@googlegroups.com
 {%- endif %}


### PR DESCRIPTION
This fixes #112 by removing the gitter badge - it's hard to compute the URL correctly, and projects might not use Gitter. Also makes the org integration a bit nicer, as exact capitalization no longer needs to be followed.
