### PR TITLE
fix: copier and pydantic 2 are not compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ Install `copier` and `copier-templates-extensions`. Using [pipx][], that's:
 
 ```bash
 pipx install copier
-pipx inject copier copier-templates-extensions
+pipx inject copier copier-templates-extensions "pydandic<2"
 ```
 
-Now, run copier to generate your project:
+(Copier<=8.0.0 and pydantic 2 are incompatible.) Now, run copier to generate
+your project:
 
 ```bash
 copier copy gh:scientific-python/cookie <pkg> --UNSAFE

--- a/noxfile.py
+++ b/noxfile.py
@@ -258,7 +258,10 @@ def nox_session(session, backend):
 
 @nox.session()
 def compare_copier(session):
-    session.install("cookiecutter", "copier", "copier-templates-extensions")
+    # Pydantic 2.0 breaks copier <= 8.0.0
+    session.install(
+        "cookiecutter", "copier", "copier-templates-extensions", "pydantic<2"
+    )
 
     tmp_dir = session.create_tmp()
     session.cd(tmp_dir)


### PR DESCRIPTION
See https://github.com/copier-org/copier/issues/1225.
