### PR TITLE
chore: update ruff repo link

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: blacken-docs
         additional_dependencies: [black==23.1.0]
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.0.270"
     hooks:
       - id: ruff

--- a/src/sp_repo_review/checks/precommit.py
+++ b/src/sp_repo_review/checks/precommit.py
@@ -82,7 +82,7 @@ class PC180(PreCommit):
 class PC191(PreCommit):
     "Ruff show fixes if fixes enabled"
     requires = {"PC190"}
-    repo = "https://github.com/charliermarsh/ruff-pre-commit"
+    repo = "https://github.com/astral-sh/ruff-pre-commit"
 
     @classmethod
     def check(cls, precommit: dict[str, Any]) -> bool | None:

--- a/src/sp_repo_review/checks/precommit.py
+++ b/src/sp_repo_review/checks/precommit.py
@@ -56,7 +56,7 @@ class PC111(PreCommit):
 
 class PC190(PreCommit):
     "Uses Ruff"
-    repo = "https://github.com/charliermarsh/ruff-pre-commit"
+    repo = "https://github.com/astral-sh/ruff-pre-commit"
 
 
 class PC140(PreCommit):


### PR DESCRIPTION
Ruff has moved to a proper organization a couple weeks back. While GitHub automatically redirects, it's probably best to update the corresponding check.