### PR TITLE
fix: cookiecutter 2.2 removed jinja2_time

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -20,8 +20,7 @@
     "mesonpy",
     "maturin"
   ],
-  "_extensions": ["jinja2_time.TimeExtension"],
-  "__year": "{% now 'utc', '%Y' %}",
+  "__year": "2023",
   "__project_slug": "{{ cookiecutter.project_name | lower | replace('-', '_') | replace('.', '_') }}",
   "__type": "{{ 'compiled' if cookiecutter.backend in ['pybind11', 'skbuild', 'mesonpy', 'maturin'] else 'pure' }}",
   "__answers": "",


### PR DESCRIPTION
Cookiecutter 2.2 is incompatible out of the box with cookie. This gets it working again for now, we'll see what happens on https://github.com/cookiecutter/cookiecutter/pull/1779. I'd like to keep support for <2.2 for a while, until it's rare from package managers and such.
