### PR TITLE
fix: nice cookie descriptions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,5 +89,5 @@ repos:
         name: Cog the pages
         language: python
         entry: cog -P -r -I ./helpers
-        files: "^docs/pages/guides/(packaging_compiled|docs).md"
+        files: "^docs/pages/guides/(packaging_compiled|docs).md|^copier.yml"
         additional_dependencies: [cogapp, cookiecutter]

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ below, and skip installation). Then run:
 cookiecutter gh:scientific-python/cookie
 ```
 
+If you are using cookiecutter 2.2+, you will get descriptions for the options.
+
 #### To use (classic cruft version)
 
 You can also use [cruft][], which adds the ability update to cookiecutter

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -24,5 +24,15 @@
   "__project_slug": "{{ cookiecutter.project_name | lower | replace('-', '_') | replace('.', '_') }}",
   "__type": "{{ 'compiled' if cookiecutter.backend in ['pybind11', 'skbuild', 'mesonpy', 'maturin'] else 'pure' }}",
   "__answers": "",
-  "__ci": "{{ 'github' if 'github.com' in cookiecutter.url else 'gitlab' }}"
+  "__ci": "{{ 'github' if 'github.com' in cookiecutter.url else 'gitlab' }}",
+  "__prompts__": {
+    "project_name": "The name of your project",
+    "org": "The name of your (GitHub?) org",
+    "url": "The url to your GitHub or GitLab repository",
+    "full_name": "Your name",
+    "email": "Your email",
+    "project_short_description": "A short description of your project",
+    "license": "Select a license",
+    "backend": "Choose a build backend"
+  }
 }

--- a/copier.yml
+++ b/copier.yml
@@ -1,51 +1,75 @@
+# [[[cog
+# from cog_cc import CC
+#
+# cc = CC("cookiecutter.json")
+# ]]]
+# [[[end]]]
+
+# [[[cog print(cc.project_name.yaml()) ]]]
 project_name:
   type: str
   help: The name of your project
+  # [[[end]]]
   validator: >-
     {% if not project_name %} You must provide a name for the project. {% endif
     %}
 
+# [[[cog print(cc.org.yaml()) ]]]
 org:
   type: str
   help: The name of your (GitHub?) org
+  # [[[end]]]
   validator: >-
     {% if not org %} You must provide a org for the project. It might just be
     your user name on the site (like GitHub) you are targeting. {% endif %}
 
+# [[[cog print(cc.url.yaml()) ]]]
 url:
   type: str
-  help: The URL for your repository
+  help: The url to your GitHub or GitLab repository
+  #[[[end]]]
   default: "https://github.com/{{ org }}/{{ project_name }}"
 
+# [[[cog print(cc.full_name.yaml()) ]]]
 full_name:
   type: str
   help: Your name
+  # [[[end]]]
   placeholder: My Name
   validator: >-
     {% if not full_name %} You must provide a name (possibly yours) to place in
     your config files. {% endif %}
 
+# [[[cog print(cc.email.yaml()) ]]]
 email:
   type: str
   help: Your email
+  #[[[end]]]
   placeholder: me@email.com
   validator: >-
     {% if not email %} You must provide an email (possibly yours) to place in
     your config files, as required by PyPI. {% endif %}
 
+# [[[cog print(cc.project_short_description.yaml()) ]]]
 project_short_description:
   type: str
+  help: A short description of your project
+  #[[[end]]]
   default: A great package.
 
+# [[[cog print(cc.license.yaml()) ]]]
 license:
   help: Select a license
+  #[[[end]]]
   choices:
     - BSD
     - Apache
     - MIT
 
+# [[[cog print(cc.backend.yaml()) ]]]
 backend:
   help: Choose a build backend
+  #[[[end]]]
   choices:
     "Hatchling                      - Pure Python (recommended)": hatch
     "Flit-core                      - Pure Python (minimal)": flit

--- a/helpers/cog_cc.py
+++ b/helpers/cog_cc.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+
+@dataclasses.dataclass(frozen=True)
+class Option:
+    name: str
+    default: str
+    prompt: str
+    type: str
+
+    def yaml(self) -> str:
+        type_str = f"  type: {self.type}\n" if self.type else ""
+        return f"{self.name}:\n{type_str}  help: {self.prompt}"
+
+
+class CC:
+    def __init__(self, filename: str):
+        with Path(filename).open(encoding="utf-8") as f:
+            data = json.load(f)
+
+        for name, value in data.items():
+            if name.startswith("_"):
+                continue
+
+            setattr(
+                self,
+                name,
+                Option(
+                    name,
+                    value,
+                    data.get("__prompts__", {}).get(name, name),
+                    "str" if isinstance(value, str) else "",
+                ),
+            )


### PR DESCRIPTION
If a user is using cookiecutter 2.2 (from about 3-4 hours ago, feature added in https://github.com/cookiecutter/cookiecutter/pull/1881), they will get nice descriptions now! Using cog to keep these in sync with copier.

Copier's choices are still much nicer, but this is a great step in the right direction.

New output when using cookiecutter 2.2+:

```
The name of your project [package]:
The name of your (GitHub?) org [org]:
The url to your GitHub or GitLab repository [https://github.com/org/package]:
Your name [My Name]:
Your email [me@email.com]:
A short description of your project [A great package.]:
Select a license:
1 - BSD
2 - Apache
3 - MIT
Choose from 1, 2, 3 [1]:
Choose a build backend:
1 - hatch
2 - flit
3 - pdm
4 - trampolim
5 - whey
6 - poetry
7 - setuptools621
8 - setuptools
9 - pybind11
10 - skbuild
11 - mesonpy
12 - maturin
Choose from 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 [1]:
```

(old output on old versions)
