### PR TITLE
fix: message cls crash

### DIFF
--- a/src/sp_repo_review/checks/ruff.py
+++ b/src/sp_repo_review/checks/ruff.py
@@ -87,9 +87,9 @@ class RF1xx(Ruff):
     @classmethod
     def check(cls: type[RuffMixin], pyproject: dict[str, Any]) -> bool:
         """
-        Must select the {cls.name} `{cls.code}` checks. Recommended:
+        Must select the {self.name} `{self.code}` checks. Recommended:
         ```toml
-        select = ["{cls.code}"]  # {cls.name}
+        select = ["{self.code}"]  # {self.name}
         ```
         """
 


### PR DESCRIPTION
Discovered by @jarrodmillman. Leftover from old design where `cls` was used instead of `self`. We could also provide `cls` in repo-review (as a shortcut for `self.__class__`, since a user might have `cls` (like here) and not realize that they need `self` in the docstrings.
