### PR TITLE
fix: help text / choice improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,21 +74,21 @@ Install `copier` and `copier-templates-extensions`. Using [pipx][], that's:
 
 ```bash
 pipx install copier
-pipx inject copier copier-templates-extensions "pydantic<2"
+pipx inject copier copier-templates-extensions
 ```
 
-(Copier<=8.0.0 and pydantic 2 are incompatible.) Now, run copier to generate
-your project:
+Now, run copier to generate your project:
 
 ```bash
-copier copy gh:scientific-python/cookie <pkg> --UNSAFE
+copier copy gh:scientific-python/cookie <pkg> --trust
 ```
 
-(`<pkg>` is the path to put the new project.)
+(`<pkg>` is the path to put the new project. If copier is old, use `--UNSAFE`
+instead of `--trust`)
 
-You will get a much, much nicer CLI experience with helpful descriptions and
-answer validation. You will also get a `.copier-answers.yml` file, which will
-allow you to perform updates in the future.
+You will get a nicer CLI experience with answer validation. You will also get a
+`.copier-answers.yml` file, which will allow you to perform updates in the
+future.
 
 > Note: Add `--vcs-ref=HEAD` to get the latest version instead of the last
 > tagged version; HEAD always passes tests (and is what cookiecutter uses).
@@ -103,7 +103,8 @@ below, and skip installation). Then run:
 cookiecutter gh:scientific-python/cookie
 ```
 
-If you are using cookiecutter 2.2+, you will get descriptions for the options.
+If you are using cookiecutter 2.2.3+, you will get nice descriptions for the
+options like copier!
 
 #### To use (classic cruft version)
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -33,6 +33,20 @@
     "email": "Your email",
     "project_short_description": "A short description of your project",
     "license": "Select a license",
-    "backend": "Choose a build backend"
+    "backend": {
+      "__prompt__": "Choose a build backend",
+      "hatch": "Hatchling                      - Pure Python (recommended)",
+      "flit": "Flit-core                      - Pure Python (minimal)",
+      "pdm": "PDM-backend                    - Pure Python",
+      "trampolim": "Trampolim                      - Pure Python",
+      "whey": "Whey                           - Pure Python",
+      "poetry": "Poetry                         - Pure Python",
+      "setuptools621": "Setuptools with pyproject.toml - Pure Python",
+      "setuptools": "Setuptools with setup.py       - Pure Python",
+      "pybind11": "Setuptools and pybind11        - Compiled C++",
+      "skbuild": "Scikit-build-core             - Compiled C++ (recommended)",
+      "mesonpy": "Meson-python                  - Compiled C++ (also good)",
+      "maturin": "Maturin                       - Compiled Rust (recommended)"
+    }
   }
 }

--- a/copier.yml
+++ b/copier.yml
@@ -27,7 +27,7 @@ org:
 url:
   type: str
   help: The url to your GitHub or GitLab repository
-  #[[[end]]]
+  # [[[end]]]
   default: "https://github.com/{{ org }}/{{ project_name }}"
 
 # [[[cog print(cc.full_name.yaml()) ]]]
@@ -44,7 +44,7 @@ full_name:
 email:
   type: str
   help: Your email
-  #[[[end]]]
+  # [[[end]]]
   placeholder: me@email.com
   validator: >-
     {% if not email %} You must provide an email (possibly yours) to place in
@@ -54,22 +54,21 @@ email:
 project_short_description:
   type: str
   help: A short description of your project
-  #[[[end]]]
+  # [[[end]]]
   default: A great package.
 
 # [[[cog print(cc.license.yaml()) ]]]
 license:
   help: Select a license
-  #[[[end]]]
   choices:
     - BSD
     - Apache
     - MIT
+  # [[[end]]]
 
 # [[[cog print(cc.backend.yaml()) ]]]
 backend:
   help: Choose a build backend
-  #[[[end]]]
   choices:
     "Hatchling                      - Pure Python (recommended)": hatch
     "Flit-core                      - Pure Python (minimal)": flit
@@ -83,6 +82,7 @@ backend:
     "Scikit-build-core              - Compiled C++ (recommended)": skbuild
     "Meson-python                   - Compiled C++ (also good)": mesonpy
     "Maturin                        - Compiled Rust (recommended)": maturin
+  # [[[end]]]
 
 _templates_suffix: ""
 

--- a/docs/pages/guides/packaging_compiled.md
+++ b/docs/pages/guides/packaging_compiled.md
@@ -99,7 +99,8 @@ with render_cookie(backend="maturin") as maturin:
 
 {% tabs %} {% tab skbc Scikit-build-core %}
 
-Example `CMakeLists.txt` file:
+Example `CMakeLists.txt` file (using pybind11, so include `pybind11` in
+`build-system.requires` too):
 
 <!-- prettier-ignore-start -->
 <!-- [[[cog
@@ -122,7 +123,8 @@ install(TARGETS _core DESTINATION ${SKBUILD_PROJECT_NAME})
 
 {% endtab %} {% tab meson Meson-python %}
 
-Example `meson.build` file:
+Example `meson.build` file (using pybind11, so include `pybind11` in
+`build-system.requires` too):
 
 <!-- prettier-ignore-start -->
 <!-- [[[cog
@@ -170,6 +172,8 @@ py.extension_module('_core',
 <!-- prettier-ignore-end -->
 
 {% endtab %} {% tab maturin Maturin %}
+
+Example `Cargo.toml` file:
 
 <!-- prettier-ignore-start -->
 <!-- [[[cog

--- a/noxfile.py
+++ b/noxfile.py
@@ -258,10 +258,7 @@ def nox_session(session, backend):
 
 @nox.session()
 def compare_copier(session):
-    # Pydantic 2.0 breaks copier <= 8.0.0
-    session.install(
-        "cookiecutter", "copier", "copier-templates-extensions", "pydantic<2"
-    )
+    session.install("cookiecutter", "copier", "copier-templates-extensions")
 
     tmp_dir = session.create_tmp()
     session.cd(tmp_dir)


### PR DESCRIPTION
Cookiecutter 2.2.3 now provides full help text even on the choices. 2.2.0 and 2.2.2 produce a weird repr of a OrderedDict, but still work (and old versions work like before). Synced choices with cog now too.

Updated for latest copier features, including `--safe` and the pydantic bug avoided.

New display:

```
The name of your project [package]:
The name of your (GitHub?) org [org]:
The url to your GitHub or GitLab repository [https://github.com/org/package]:
Your name [My Name]:
Your email [me@email.com]:
A short description of your project [A great package.]:
Select a license:
1 - BSD
2 - Apache
3 - MIT
Choose from 1, 2, 3 [1]:
Choose a build backend:
1 - Hatchling                      - Pure Python (recommended)
2 - Flit-core                      - Pure Python (minimal)
3 - PDM-backend                    - Pure Python
4 - Trampolim                      - Pure Python
5 - Whey                           - Pure Python
6 - Poetry                         - Pure Python
7 - Setuptools with pyproject.toml - Pure Python
8 - Setuptools with setup.py       - Pure Python
9 - Setuptools and pybind11        - Compiled C++
10 - Scikit-build-core             - Compiled C++ (recommended)
11 - Meson-python                  - Compiled C++ (also good)
12 - Maturin                       - Compiled Rust (recommended)
Choose from 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 [1]:
```
