### PR TITLE
fix: drop extra branches

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -5,9 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - main
-      - develop
 
 concurrency:
   group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}

--- a/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type!='compiled' %}cd.yml{% endif %}
+++ b/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type!='compiled' %}cd.yml{% endif %}
@@ -5,9 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - main
-      - develop
   release:
     types:
       - published


### PR DESCRIPTION
Drop extra branches. The default is solidly `main` now, and ppl can update if needed. Simpler template better.
