### PR TITLE
Fix erroneous reference to YAML in packaging.md

### DIFF
--- a/docs/pages/tutorials/packaging.md
+++ b/docs/pages/tutorials/packaging.md
@@ -61,7 +61,7 @@ The last element your package needs is a `pyproject.toml` file, placed in the
 root directory.
 
 ```bash
-touch pyproject.yaml
+touch pyproject.toml
 ```
 
 Fill in the minimally required metadata, which includes the package name,


### PR DESCRIPTION
Very small change, but the tutorial should say `toml` here instead of `yaml`. This fixes the typo.