### PR TITLE
fix(sp-repo-review): report correct message for github.ref

### DIFF
--- a/src/sp_repo_review/checks/github.py
+++ b/src/sp_repo_review/checks/github.py
@@ -78,7 +78,7 @@ class GH102(GitHub):
 
         ```yaml
         concurrency:
-          group: ${{{{ github.workflow }}}}-${{{{ github.head_ref }}}}
+          group: ${{{{ github.workflow }}}}-${{{{ github.ref }}}}
           cancel-in-progress: true
         ```
         """


### PR DESCRIPTION
This was fixed elsewhere, but not here.
