### PR TITLE
fix: remove limits on repo-review

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 dynamic = ["version", "readme"]
 dependencies = [
   "pyyaml",
-  "repo-review>=0.7,<0.10",
+  "repo-review",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
We have had issues with the upper cap in the past, and now we have having issues with the lower cap, so let's just remove them. See https://github.com/scientific-python/repo-review/issues/123
