### PR TITLE
Fix the pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,8 @@
 - id: sp-repo-review
   name: sp-repo-review
   description: Check for configuration best practices
-  entry: repo-review
+  entry: repo-review .
   language: python
   types_or: [text]
+  pass_filenames: false
   minimum_pre_commit_version: 2.9.0

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
-id: sp-repo-review
-name: sp-repo-review
-description: Check for configuration best practices
-entry: repo-review
-language: python
-types_or: [text]
-minimum_pre_commit_version: 2.9.0
+- id: sp-repo-review
+  name: sp-repo-review
+  description: Check for configuration best practices
+  entry: repo-review
+  language: python
+  types_or: [text]
+  minimum_pre_commit_version: 2.9.0

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Or pre-commit:
   rev: <version>
   hooks:
     - id: sp-repo-review
+      additional_dependencies: ["repo-review[cli]"]
 ```
 
 ## List of checks


### PR DESCRIPTION
When trying to use the pre-commit hook as suggested by https://github.com/scientific-python/repo-review/issues/123#issuecomment-1672479812 I found several issues:

1. The hook would fail to install due to the `.pre-commit-hooks.yaml` file not containing a `list` and instead being a `dict`.
2. `repo-review` would fail to run if it was passed all the individual files, which is the default behavior of `pre-commit`.
3. Several dependencies for `repo-review` to function as a CLI tool for `pre-commit` failed to be installed.

This attempts to solve all these small issues.