### PR TITLE
docs: fix encoding; clarify example is for setup.cfg

### DIFF
--- a/docs/pages/patterns/data_files.md
+++ b/docs/pages/patterns/data_files.md
@@ -56,7 +56,7 @@ data file, the naïve solution is just to hard-code the path to that file.
 ```python
 from pathlib import Path
 
-spacings_txt = Path("peak_spacings/LaB6.txt").read_text(encoding="utf=8")
+spacings_txt = Path("peak_spacings/LaB6.txt").read_text(encoding="utf-8")
 ```
 
 But this is not a good solution because:
@@ -111,7 +111,8 @@ package.peak_spacings =
 ```
 
 **Or**, you can use automatic data inclusion (this is the default if you use
-`pyproject.toml` `[project]` config in Setuptools 61+):
+`pyproject.toml` `[project]` config in Setuptools 61+). To enable this with
+`setup.cfg`:
 
 ```ini
 [options]
@@ -139,7 +140,7 @@ import importlib_resources as resources
 
 ref = resources.files("package.peak_spacings") / "LaB6.txt"
 
-spacings_txt = ref.read_text(encoding="utf=8")
+spacings_txt = ref.read_text(encoding="utf-8")
 
 # If you have an API that requires an on-disk file, you can do this instead:
 with resources.as_file(ref) as path:


### PR DESCRIPTION
Thanks for the docs! Here are a few minor tweaks.

Fix a few encoding values from `utf=8` to `utf-8`.

The setuptools data file example was a bit confusing, since the default behaviour of `pyproject.toml` is described, but is followed by an example for `setup.cfg`.

Perhaps in a few years all `setup.cfg` examples should be either removed or replaced with standard-based `pyproject.toml`.