### PR TITLE
fix: add validate-pyproject to checks

### DIFF
--- a/docs/_includes/interactive_repo_review.html
+++ b/docs/_includes/interactive_repo_review.html
@@ -19,7 +19,12 @@
   root.render(
     <App
       header={false}
-      deps={["sp-repo-review==2023.08.03", "repo-review==0.9.2"]}
+      deps={[
+        "sp-repo-review==2023.08.03",
+        "repo-review==0.9.2",
+        "validate-pyproject==0.14",
+        "scikit-build-core==0.5.0",
+      ]}
     />,
   );
 </script>


### PR DESCRIPTION
This is supported now. Also adding scikit-build-core for it's validation schema.
