### PR TITLE
chore: drop 3.11 & use pypy3.10

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -40,11 +40,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.11", "3.12"]
+        python-version: ["3.8", "3.12"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
         include:
-          - python-version: pypy-3.9
+          - python-version: pypy-3.10
             runs-on: ubuntu-latest
 
     steps:

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/__init__.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/__init__.py
@@ -27,4 +27,4 @@ __version__ = "0.1.0"
 
 {%- endif %}
 
-__all__ = ("__version__",)
+__all__ = ["__version__"]


### PR DESCRIPTION
Since 3.12 is stable, no need to have a default 3.11 job too. Minor touchups.
