### PR TITLE
fix: fix logic broken if more than one hook in Ruff

### DIFF
--- a/src/sp_repo_review/checks/precommit.py
+++ b/src/sp_repo_review/checks/precommit.py
@@ -102,8 +102,7 @@ class PC191(PreCommit):
                         and "--fix" in hook["args"]
                     ):
                         return "--show-fixes" in hook["args"]
-                    return None
-
+                return None
         return False
 
 


### PR DESCRIPTION
Bug exposed by adding a second hook (#299).
