### PR TITLE
fix: show_error_codes deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ for family, grp in itertools.groupby(collected.checks.items(), key=lambda x: x[1
 ### MyPy
 - [`MY100`](https://learn.scientific-python.org/development/guides/style#MY100): Uses MyPy (pyproject config)
 - [`MY101`](https://learn.scientific-python.org/development/guides/style#MY101): MyPy strict mode
-- [`MY102`](https://learn.scientific-python.org/development/guides/style#MY102): MyPy show error codes
+- `MY102`: MyPy show_error_codes deprecated
 - [`MY103`](https://learn.scientific-python.org/development/guides/style#MY103): MyPy warn unreachable
 - [`MY104`](https://learn.scientific-python.org/development/guides/style#MY104): MyPy enables ignore-without-code
 - [`MY105`](https://learn.scientific-python.org/development/guides/style#MY105): MyPy enables redundant-expr

--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -552,7 +552,6 @@ this:
 files = "src"
 python_version = "3.8"
 strict = true
-show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
 
@@ -579,8 +578,6 @@ and `ignore-without-code` {% rr MY104 %}, `redundant-expr` {% rr MY105 %}, and
 `truthy-bool` {% rr MY106 %} can trigger too often (like on `sys.platform`
 checks) and have to be ignored occasionally, but can find some signifiant logic
 errors in your typing.
-
-{% rr MY102 %} You should enable `show_error_codes`.
 
 [mypy page]: {% link pages/guides/mypy.md %}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,6 @@ files = ["src", "tests"]
 python_version = "3.10"
 warn_unused_configs = true
 strict = true
-show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
 disallow_untyped_defs = false

--- a/src/sp_repo_review/checks/mypy.py
+++ b/src/sp_repo_review/checks/mypy.py
@@ -57,28 +57,21 @@ class MY101(MyPy):
 
 
 class MY102(MyPy):
-    "MyPy show error codes"
+    "MyPy show_error_codes deprecated"
 
     requires = {"MY100"}
-    url = mk_url("style")
 
     @staticmethod
     def check(pyproject: dict[str, Any]) -> bool:
         """
-        Must have `show_error_codes = true`. This will print helpful error codes
-        for users that clarify why something fails if you need to skip it.
-
-        ```toml
-        [tool.mypy]
-        show_error_codes = true
-        ```
+        Must not have `show_error_codes`. Use `hide_error_codes` instead (since MyPy v0.990).
         """
 
         match pyproject:
-            case {"tool": {"mypy": {"show_error_codes": True}}}:
-                return True
-            case _:
+            case {"tool": {"mypy": {"show_error_codes": object()}}}:
                 return False
+            case _:
+                return True
 
 
 class MY103(MyPy):

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -325,7 +325,6 @@ files = ["src", "tests"]
 python_version = "3.8"
 warn_unused_configs = true
 strict = true
-show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
 disallow_untyped_defs = false


### PR DESCRIPTION
This has been deprecated for quite a while and I just noticed it when working on https://github.com/python/mypy/issues/16491.
