### PR TITLE
fix: support simple Ruff extend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ testpaths = ["tests"]
 
 
 [tool.mypy]
+mypy_path = ["src"]
 files = ["src", "tests"]
 python_version = "3.10"
 warn_unused_configs = true

--- a/src/sp_repo_review/checks/ruff.py
+++ b/src/sp_repo_review/checks/ruff.py
@@ -117,7 +117,7 @@ class RF1xx(Ruff):
 
         ```toml
         [tool.ruff.lint]
-        select = [
+        extend-select = [
           "{self.code}",  # {self.name}
         ]
         ```

--- a/tests/packages/ruff_extend/pyproject.toml
+++ b/tests/packages/ruff_extend/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.repo-review]
+select = ["RF", "PY001"]
+
+[tool.ruff.lint]
+select = ["ALL"]

--- a/tests/packages/ruff_extend/ruff.toml
+++ b/tests/packages/ruff_extend/ruff.toml
@@ -1,0 +1,2 @@
+extend = "pyproject.toml"
+target-version = "3.8"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -26,3 +26,12 @@ def test_local():
     package = DIR.parent
     results = process(package)
     assert results
+
+
+@pytest.mark.parametrize("name", ["ruff_extend"])
+def test_examples(name: str) -> None:
+    package = DIR / "packages" / name
+    _, results = process(package)
+
+    failures = [r for r in results if r.result is not None and not r.result]
+    assert not failures

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from sp_repo_review.checks.ruff import merge
+
+
+def test_merge():
+    a = {"a": 1, "b": [1], "c": {"aa": 2, "bb": [2]}, "d": {"one": 1}}
+    b = {"b": [3], "c": {"bb": [4], "cc": 5}, "e": {"two": 2}}
+
+    assert merge(a, b) == {
+        "a": 1,
+        "b": [3],
+        "c": {"aa": 2, "bb": [4], "cc": 5},
+        "d": {"one": 1},
+        "e": {"two": 2},
+    }


### PR DESCRIPTION
Fix #311. Currently only top level configuration supported, but that that's what the checks are mostly targeting anyway.

Also added a test for `ALL` & extend.
