### PR TITLE
fix: loosen required summary flag

### DIFF
--- a/src/sp_repo_review/checks/pyproject.py
+++ b/src/sp_repo_review/checks/pyproject.py
@@ -205,7 +205,8 @@ class PP308(PyProject):
     @staticmethod
     def check(pyproject: dict[str, Any]) -> bool:
         """
-        `-ra` should be in `addopts = [...]` (print summary of all fails/errors).
+        An explicit summary flag like `-ra` should be in `addopts = [...]`
+        (print summary of all fails/errors).
 
         ```toml
         [tool.pytest.ini_options]
@@ -213,7 +214,7 @@ class PP308(PyProject):
         ```
         """
         options = pyproject["tool"]["pytest"]["ini_options"]
-        return "-ra" in options.get("addopts", [])
+        return any(opt.startswith("-r") for opt in options.get("addopts", []))
 
 
 class PP309(PyProject):


### PR DESCRIPTION
This loosens the required flag; any flag is fine, not just `-ra`; that
indicates you know what summary level you want rather than taking the default.

See https://github.com/astropy/astropy/pull/15367.
