### PR TITLE
fix: nicer default for pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,3 +6,4 @@
   types_or: [text]
   pass_filenames: false
   minimum_pre_commit_version: 2.9.0
+  additional_dependencies: ["repo-review[cli]"]

--- a/README.md
+++ b/README.md
@@ -284,8 +284,11 @@ Or pre-commit:
   rev: <version>
   hooks:
     - id: sp-repo-review
-      additional_dependencies: ["repo-review[cli]"]
 ```
+
+If you use `additional_dependencies` to add more plugins, like
+`validate-pyproject`, you should also include `"repo-review[cli]"` to ensure the
+CLI requirements are included.
 
 ## List of checks
 


### PR DESCRIPTION
Nicer default for projects that aren't using `additional_dependencies`.
