### PR TITLE
fix: accept other filenames for LICENSE

### DIFF
--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -52,7 +52,9 @@ class PY003(General):
         "Projects must have a license"
         spellings = ("LICENSE", "LICENCE", "COPYING")
         return any(
-            p.name.startswith(spelling) for p in package.iterdir() for spelling in spellings
+            p.name.startswith(spelling)
+            for p in package.iterdir()
+            for spelling in spellings
         )
 
 

--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -50,7 +50,12 @@ class PY003(General):
     @staticmethod
     def check(package: Traversable) -> bool:
         "Projects must have a license"
-        return len([p for p in package.iterdir() if "LICENSE" in p.name]) > 0
+        spellings = ("LICENSE", "LICENCE", "COPYING")
+        return any(
+            p
+            for p in package.iterdir()
+            if any(spelling in p.name for spelling in spellings)
+        )
 
 
 class PY004(General):

--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -52,7 +52,7 @@ class PY003(General):
         "Projects must have a license"
         spellings = ("LICENSE", "LICENCE", "COPYING")
         return any(
-            spelling in p.name for spelling in spellings for p in package.iterdir()
+            spelling in p.name for p in package.iterdir() for spelling in spellings
         )
 
 

--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -52,7 +52,7 @@ class PY003(General):
         "Projects must have a license"
         spellings = ("LICENSE", "LICENCE", "COPYING")
         return any(
-            any(spelling in p.name for spelling in spellings) for p in package.iterdir()
+            spelling in p.name for spelling in spellings for p in package.iterdir()
         )
 
 

--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -52,7 +52,7 @@ class PY003(General):
         "Projects must have a license"
         spellings = ("LICENSE", "LICENCE", "COPYING")
         return any(
-            spelling in p.name for p in package.iterdir() for spelling in spellings
+            p.name.startswith(spelling) for p in package.iterdir() for spelling in spellings
         )
 
 

--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -52,8 +52,7 @@ class PY003(General):
         "Projects must have a license"
         spellings = ("LICENSE", "LICENCE", "COPYING")
         return any(
-            any(spelling in p.name for spelling in spellings)
-            for p in package.iterdir()
+            any(spelling in p.name for spelling in spellings) for p in package.iterdir()
         )
 
 

--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -52,9 +52,8 @@ class PY003(General):
         "Projects must have a license"
         spellings = ("LICENSE", "LICENCE", "COPYING")
         return any(
-            p
+            any(spelling in p.name for spelling in spellings)
             for p in package.iterdir()
-            if any(spelling in p.name for spelling in spellings)
         )
 
 


### PR DESCRIPTION
The added filenames are LICENCE and COPYING, both of which are commonly used. There might be others accepted by GitHub, but the list can easily be extended.

This check could be a little slower due to having to do three times the number of string comparisons, but hopefully that is counteracted by the switch to using a generator, ensuring that an intermediate list doesn't have to be built, and that the check can terminate as soon as a file is found.

Fixes https://github.com/scientific-python/cookie/issues/326