### PR TITLE
remove PEP0563's `annotations` since PEP0649 has been accepted

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -373,7 +373,6 @@ ignore = [
   "PLR2004",  # Magic value used in comparison
   "ISC001",   # Conflicts with formatter
 ]
-isort.required-imports = ["from __future__ import annotations"]
 # Uncomment if using a _compat.typing backport
 # typing-modules = ["{{ cookiecutter.__project_slug }}._compat.typing"]
 


### PR DESCRIPTION
Thanks for developing this great package. It makes starting new projects much easier!

https://peps.python.org/pep-0649/ replaces stringifying done in https://peps.python.org/pep-0563/.
See https://github.com/astropy/astropy/issues/12770#issuecomment-1843725055 for a discussion where runtime use of type hints is important and `from __future__ import annotations` doesn't play nice.