### PR TITLE
fix: incomplete coverage config

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -316,8 +316,7 @@ testpaths = [
 
 [tool.coverage]
 run.source = ["{{ cookiecutter.__project_slug }}"]
-port.exclude_lines = [
-  'pragma: no cover',
+report.exclude_also = [
   '\.\.\.',
   'if typing.TYPE_CHECKING:',
 ]


### PR DESCRIPTION
There was a slight error in the default coverage configuration in `pyproject.toml`. 
This PR fixes the error and switches from the old `exclude_lines` to the newer and (I believe) recommended `exclude_also`.