### PR TITLE
fix: docs serve command

### DIFF
--- a/{{cookiecutter.project_name}}/.github/CONTRIBUTING.md
+++ b/{{cookiecutter.project_name}}/.github/CONTRIBUTING.md
@@ -19,7 +19,7 @@ specific jobs:
 ```console
 $ nox -s lint  # Lint only
 $ nox -s tests  # Python tests
-$ nox -s docs -- serve  # Build and serve the docs
+$ nox -s docs -- --serve  # Build and serve the docs
 $ nox -s build  # Make an SDist and wheel
 ```
 
@@ -95,7 +95,7 @@ nox -s docs
 You can see a preview with:
 
 ```bash
-nox -s docs -- serve
+nox -s docs -- --serve
 ```
 
 # Pre-commit


### PR DESCRIPTION
The command shown in the `Contributing` guide was not matching the actual command from the `noxfile`.
This PR makes it consistent.
Let me know if you would prefer to change the noxfile parameter instead.