### PR TITLE
fix: prepare for artifact v4

### DIFF
--- a/.github/workflows/reusable-cookie.yml
+++ b/.github/workflows/reusable-cookie.yml
@@ -171,6 +171,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
+          name: Packages
           path: dist
 
   pass:

--- a/docs/pages/guides/gha_pure.md
+++ b/docs/pages/guides/gha_pure.md
@@ -79,6 +79,7 @@ dist:
 
     - uses: actions/upload-artifact@v3
       with:
+        name: Packages
         path: dist/*
 
     - name: Check metadata
@@ -103,6 +104,11 @@ GitHub Actions (in fact, they use it to setup other applications).
 
 We upload the artifact just to make it available via the GitHub PR/Checks API.
 You can download a file to test locally if you want without making a release.
+
+{: .warning }
+
+> As of `upload-artifact@v4`, the artifact name must be unique. Extending an
+> existing artifact is no longer supported.
 
 We also add an optional check using twine for the metadata (it will be tested
 later in the upload action for the release job, as well).
@@ -142,7 +148,7 @@ publish:
   steps:
     - uses: actions/download-artifact@v3
       with:
-        name: artifact
+        name: Packages
         path: dist
 
     - uses: pypa/gh-action-pypi-publish@release/v1
@@ -168,7 +174,7 @@ publish:
   steps:
     - uses: actions/download-artifact@v3
       with:
-        name: artifact
+        name: Packages
         path: dist
 
     - uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/pages/guides/gha_wheels.md
+++ b/docs/pages/guides/gha_wheels.md
@@ -184,9 +184,7 @@ upload_all:
     - name: Merge files
       run: |
         mkdir dist
-        mv all/*/* .
-        rmdir all/*
-        rmdir all
+        mv all/*/* dist
 
     - uses: pypa/gh-action-pypi-publish@release/v1
 ```
@@ -216,7 +214,7 @@ upload_all:
     - name: Merge files
       run: |
         mkdir dist
-        mv all/*/* .
+        mv all/*/* dist
 
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/docs/pages/guides/gha_wheels.md
+++ b/docs/pages/guides/gha_wheels.md
@@ -38,8 +38,8 @@ This will run on releases. If you use a develop branch, you could include
 `pull_request: branches: [stable]`, since it changes rarely. GitHub actions also
 [has a `workflow_dispatch` option][workflow_dispatch], which will allow you to
 click a button in the GUI to trigger a build, which is perfect for testing
-wheels before making a release; you can download them from "artifacts". You can
-even define variables that you can set in the GUI and access in the CI!
+wheels before making a release; you can download them from the "artifacts". You
+can even define variables that you can set in the GUI and access in the CI!
 
 <!-- prettier-ignore-start -->
 [workflow_dispatch]: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
@@ -94,6 +94,7 @@ make_sdist:
 
     - uses: actions/upload-artifact@v3
       with:
+        name: SDist
         path: dist/*.tar.gz
 ```
 
@@ -126,6 +127,7 @@ build_wheels:
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:
+        name: Wheels-${{ matrix.os }}
         path: wheelhouse/*.whl
 ```
 
@@ -177,8 +179,14 @@ upload_all:
   steps:
     - uses: actions/download-artifact@v3
       with:
-        name: artifact
-        path: dist
+        path: all
+
+    - name: Merge files
+      run: |
+        mkdir dist
+        mv all/*/* .
+        rmdir all/*
+        rmdir all
 
     - uses: pypa/gh-action-pypi-publish@release/v1
 ```
@@ -203,8 +211,14 @@ upload_all:
   steps:
     - uses: actions/download-artifact@v3
       with:
-        name: artifact
-        path: dist
+        path: all
+
+    - name: Merge files
+      run: |
+        mkdir dist
+        mv all/*/* .
+        rmdir all/*
+        rmdir all
 
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/docs/pages/guides/gha_wheels.md
+++ b/docs/pages/guides/gha_wheels.md
@@ -217,8 +217,6 @@ upload_all:
       run: |
         mkdir dist
         mv all/*/* .
-        rmdir all/*
-        rmdir all
 
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type=='compiled' %}cd.yml{% endif %}
+++ b/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type=='compiled' %}cd.yml{% endif %}
@@ -67,7 +67,7 @@ jobs:
       - name: Merge files
         run: |
           mkdir dist
-          mv all/*/* .
+          mv all/*/* dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type=='compiled' %}cd.yml{% endif %}
+++ b/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type=='compiled' %}cd.yml{% endif %}
@@ -68,8 +68,6 @@ jobs:
         run: |
           mkdir dist
           mv all/*/* .
-          rmdir all/*
-          rmdir all 
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type=='compiled' %}cd.yml{% endif %}
+++ b/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type=='compiled' %}cd.yml{% endif %}
@@ -27,6 +27,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
+          name: SDist
           path: dist/*.tar.gz
 
   build_wheels:
@@ -47,6 +48,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
+          name: Wheel-{% raw %}${{ matrix.os }}{% endraw %}
           path: wheelhouse/*.whl
 
   upload_all:
@@ -60,8 +62,14 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: artifact
           path: dist
+
+      - name: Merge files
+        run: |
+          mkdir dist
+          mv all/*/* .
+          rmdir all/*
+          rmdir all 
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
I can't actually start suggesting v4 until @hynek's build-and-inspect-python-package updates, since we suggest using that for pure Python packages, and v1-v3 upload/download is not cross compatible with v4. Features of v4 are here: https://github.com/actions/toolkit/tree/main/packages/artifact#v2---whats-new - sounds nice, though the immutable artifacts is a hard one (see https://github.com/pypa/cibuildwheel/issues/1699 too). There's an issue asking for guidance here: https://github.com/actions/upload-artifact/issues/472.
