### PR TITLE
docs: fix link to homepage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
 
 [project.urls]
 Guide = "https://learn.scientific-python.org/development"
-Homepage = "https://scientific-python.github.io/cookie"
+Homepage = "https://github.com/scientific-python/cookie"
 Preview = "https://scientific-python-cookie.readthedocs.io"
 Source = "https://github.com/scientific-python/cookie"
 


### PR DESCRIPTION
I think this was a replacement mistake when moving over. This the the homepage for sp-repo-review, so linking to the GitHub page seems to make sense.

Fix #331.

Not sure what the best way to check for this might be, might be something a link check tool could support?