### PR TITLE
docs: assert correct file extension reference for wheels & sdists

### DIFF
--- a/docs/pages/guides/packaging_classic.md
+++ b/docs/pages/guides/packaging_classic.md
@@ -403,15 +403,15 @@ Python packaging goes through a 3-stage procedure if you have the above
 recommended `pyproject.toml` file. If you type `pip install .`, then
 
 1. Source is processed to make an SDist (in a virtual environment mandated by
-   pyproject.toml).
+   pyproject.toml). This SDist bears a `.tar.gz` file format.
 2. SDist is processed to make a wheel (same virtual environment).
 3. The wheel is installed.
 
 The wheel does _not_ contain `setup.*`, `pyproject.toml`, or other build code.
-It simply is a `.tar.gz` file that is named `.whl` and has a simple mapping of
-directories to installation paths and a generic metadata format. "Installing"
-really is just copying files around, and pip also pre-compiles some bytecode for
-you while doing so.
+It simply is a `.zip` format archive with the `.whl` suffix and has a simple
+mapping of directories to installation paths and a generic metadata format.
+"Installing" really is just copying files around, and pip also pre-compiles some
+bytecode for you while doing so.
 
 If you don't have a `MANIFEST.in`, the "legacy" build procedure will skip the
 SDist step, making it possible for a development build to work while a published


### PR DESCRIPTION
Hi, this PR is a _minor_ documentation fix – I was just reading through [the section **"Including/excluding files in the SDist"** in the **Classic Packaging** guide](https://learn.scientific-python.org/development/guides/packaging-classic/#includingexcluding-files-in-the-sdist) and this point caught my eye: this section talks about the procedure used to install a package via the invocation of the `pip install .` command: it incorrectly refers to the wheel as being a `.tar.gz` file while it isn't – it is fairly and commonly known that it is a `.zip` file. 

I have mentioned the correct file extension for the wheel and added a note about the SDist being in a sentence above, correctly reporting so that it can be known that the difference exists. I don't think that the incorrect documentation misguides anyone at this moment, but it's good to be correct considering the veracity of the guide since its inception.