### PR TITLE
Make meson-python usage example more idiomatic

### DIFF
--- a/docs/pages/guides/packaging_compiled.md
+++ b/docs/pages/guides/packaging_compiled.md
@@ -154,8 +154,8 @@ py.extension_module('_core',
 
 py.install_sources(
     [
-        'src/__init__.py',
-        'src/_main.py',
+        'src/package/__init__.py',
+        'src/package/_main.py',
     ],
     subdir: 'package'
 )

--- a/docs/pages/guides/packaging_compiled.md
+++ b/docs/pages/guides/packaging_compiled.md
@@ -152,7 +152,7 @@ py.extension_module('_core',
     dependencies : [pybind11_dep],
 )
 
-install_subdir('src/package', py.get_install_dir() / 'package')
+install_subdir('src/package', install_dir: py.get_install_dir() / 'package', strip_directory: true)
 ```
 <!-- prettier-ignore-end -->
 <!-- [[[end]]] -->

--- a/docs/pages/guides/packaging_compiled.md
+++ b/docs/pages/guides/packaging_compiled.md
@@ -132,38 +132,32 @@ with code_fence("meson"):
 <!-- prettier-ignore-start -->
 ```meson
 project(
-  'package',
-  'cpp',
-  version: '0.1.0',
-  license: 'BSD',
-  meson_version: '>= 0.64.0',
-  default_options: [
-    'buildtype=debugoptimized',
-    'cpp_std=c++11',
-  ],
-)
-name = 'package'
-
-py_mod = import('python')
-py = py_mod.find_installation(pure: false)
-
-pybind11_config = find_program('pybind11-config')
-pybind11_config_ret = run_command(pybind11_config, ['--includes'], check: true)
-pybind11 = declare_dependency(
-    include_directories: [pybind11_config_ret.stdout().split('-I')[-1].strip()],
+    'package',
+    'cpp',
+    version: '0.1.0',
+    license: 'BSD',
+    meson_version: '>= 1.1.0',
+    default_options: [
+        'cpp_std=c++11',
+    ],
 )
 
-install_subdir('src' / name, install_dir: py.get_install_dir() / name, strip_directory: true)
+py = import('python').find_installation(pure: false)
+pybind11_dep = dependency('pybind11')
 
 py.extension_module('_core',
     'src/main.cpp',
     subdir: 'package',
     install: true,
-    dependencies : [pybind11],
-    link_language : 'cpp',
-    override_options: [
-        'cpp_rtti=true',
-    ]
+    dependencies : [pybind11_dep],
+)
+
+py.install_sources(
+    [
+        'src/__init__.py',
+        'src/_main.py',
+    ],
+    subdir: 'package'
 )
 ```
 <!-- prettier-ignore-end -->

--- a/docs/pages/guides/packaging_compiled.md
+++ b/docs/pages/guides/packaging_compiled.md
@@ -152,13 +152,7 @@ py.extension_module('_core',
     dependencies : [pybind11_dep],
 )
 
-py.install_sources(
-    [
-        'src/package/__init__.py',
-        'src/package/_main.py',
-    ],
-    subdir: 'package'
-)
+install_subdir('src/package', py.get_install_dir() / 'package')
 ```
 <!-- prettier-ignore-end -->
 <!-- [[[end]]] -->

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.backend=='mesonpy' %}meson.build{% endif %}
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.backend=='mesonpy' %}meson.build{% endif %}
@@ -19,4 +19,4 @@ py.extension_module('_core',
     dependencies : [pybind11_dep],
 )
 
-install_subdir('src/{{ cookiecutter.__project_slug }}', py.get_install_dir() / '{{ cookiecutter.__project_slug }}')
+install_subdir('src/{{ cookiecutter.__project_slug }}', install_dir: py.get_install_dir() / '{{ cookiecutter.__project_slug }}')

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.backend=='mesonpy' %}meson.build{% endif %}
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.backend=='mesonpy' %}meson.build{% endif %}
@@ -1,5 +1,5 @@
 project(
-    'package',
+    '{{ cookiecutter.__project_slug }}',
     'cpp',
     version: '0.1.0',
     license: 'BSD',
@@ -14,15 +14,15 @@ pybind11_dep = dependency('pybind11')
 
 py.extension_module('_core',
     'src/main.cpp',
-    subdir: 'package',
+    subdir: '{{ cookiecutter.__project_slug }}',
     install: true,
     dependencies : [pybind11_dep],
 )
 
 py.install_sources(
     [
-        'src/__init__.py',
-        'src/_main.py',
+        'src/{{ cookiecutter.__project_slug }}/__init__.py',
+        'src/{{ cookiecutter.__project_slug }}/_main.py',
     ],
-    subdir: 'package'
+    subdir: '{{ cookiecutter.__project_slug }}'
 )

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.backend=='mesonpy' %}meson.build{% endif %}
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.backend=='mesonpy' %}meson.build{% endif %}
@@ -19,10 +19,4 @@ py.extension_module('_core',
     dependencies : [pybind11_dep],
 )
 
-py.install_sources(
-    [
-        'src/{{ cookiecutter.__project_slug }}/__init__.py',
-        'src/{{ cookiecutter.__project_slug }}/_main.py',
-    ],
-    subdir: '{{ cookiecutter.__project_slug }}'
-)
+install_subdir('src/{{ cookiecutter.__project_slug }}', py.get_install_dir() / '{{ cookiecutter.__project_slug }}')

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.backend=='mesonpy' %}meson.build{% endif %}
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.backend=='mesonpy' %}meson.build{% endif %}
@@ -19,4 +19,4 @@ py.extension_module('_core',
     dependencies : [pybind11_dep],
 )
 
-install_subdir('src/{{ cookiecutter.__project_slug }}', install_dir: py.get_install_dir() / '{{ cookiecutter.__project_slug }}')
+install_subdir('src/{{ cookiecutter.__project_slug }}', install_dir: py.get_install_dir() / '{{ cookiecutter.__project_slug }}', strip_directory: true)

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.backend=='mesonpy' %}meson.build{% endif %}
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.backend=='mesonpy' %}meson.build{% endif %}
@@ -1,34 +1,28 @@
 project(
-  '{{ cookiecutter.__project_slug }}',
-  'cpp',
-  version: '0.1.0',
-  license: '{{ cookiecutter.license }}',
-  meson_version: '>= 0.64.0',
-  default_options: [
-    'buildtype=debugoptimized',
-    'cpp_std=c++11',
-  ],
-)
-name = '{{ cookiecutter.__project_slug }}'
-
-py_mod = import('python')
-py = py_mod.find_installation(pure: false)
-
-pybind11_config = find_program('pybind11-config')
-pybind11_config_ret = run_command(pybind11_config, ['--includes'], check: true)
-pybind11 = declare_dependency(
-    include_directories: [pybind11_config_ret.stdout().split('-I')[-1].strip()],
+    'package',
+    'cpp',
+    version: '0.1.0',
+    license: 'BSD',
+    meson_version: '>= 1.1.0',
+    default_options: [
+        'cpp_std=c++11',
+    ],
 )
 
-install_subdir('src' / name, install_dir: py.get_install_dir() / name, strip_directory: true)
+py = import('python').find_installation(pure: false)
+pybind11_dep = dependency('pybind11')
 
 py.extension_module('_core',
     'src/main.cpp',
-    subdir: '{{ cookiecutter.__project_slug }}',
+    subdir: 'package',
     install: true,
-    dependencies : [pybind11],
-    link_language : 'cpp',
-    override_options: [
-        'cpp_rtti=true',
-    ]
+    dependencies : [pybind11_dep],
+)
+
+py.install_sources(
+    [
+        'src/__init__.py',
+        'src/_main.py',
+    ],
+    subdir: 'package'
 )


### PR DESCRIPTION
- Use `dependency('pybind11')`, which is all that is needed since Meson 1.1.0,
- Don't define an unused `py_mod` Python module,
- Remove custom C++ compile flags that are not present in the scikit-build-core and Maturin examples (nor seem needed),
- Make indentation consistent,
- ~~Use `py.install_sources` instead of a more complicated `install_subdir` call,~~