### PR TITLE
fix: Dependabot should only be required for GH repos

### DIFF
--- a/src/sp_repo_review/checks/github.py
+++ b/src/sp_repo_review/checks/github.py
@@ -161,6 +161,7 @@ class GH104(GitHub):
 class GH200(GitHub):
     "Maintained by Dependabot"
 
+    requires = {"GH100"}
     url = mk_url("gha-basic")
 
     @staticmethod


### PR DESCRIPTION
Fix https://github.com/scientific-python/cookie/issues/373.