### PR TITLE
fix: add codecov token to github action

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -75,3 +75,5 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
v4 of the codecov action requires the token to be specified as a parameter.

cf. https://github.com/codecov/codecov-action/issues/1248#issuecomment-1928486729 or https://github.com/finos/git-proxy/pull/442#issue-2123404710