### PR TITLE
Replace ToDo with link to `Writing documentation` in `Inline Documentation` tutorial

### DIFF
--- a/docs/pages/tutorials/module.md
+++ b/docs/pages/tutorials/module.md
@@ -88,8 +88,7 @@ automatically generate nice-looking HTML documentation later. Notable features:
 
 - (Optional) There is a section of one or more examples.
 
-We will revisit docstrings in the section on writing documentation [TODO: link
-once this section exists].
+We will revisit docstrings in the section on writing [documentation]({% link pages/tutorials/docs.md %}) .
 
 [snell's law]: https://en.wikipedia.org/wiki/Snell%27s_law
 [numpydoc standard]: https://numpydoc.readthedocs.io/en/latest/format.html

--- a/docs/pages/tutorials/module.md
+++ b/docs/pages/tutorials/module.md
@@ -88,7 +88,8 @@ automatically generate nice-looking HTML documentation later. Notable features:
 
 - (Optional) There is a section of one or more examples.
 
-We will revisit docstrings in the section on writing [documentation]({% link pages/tutorials/docs.md %}) .
+We will revisit docstrings in the section on writing
+[documentation]({% link pages/tutorials/docs.md %}).
 
 [snell's law]: https://en.wikipedia.org/wiki/Snell%27s_law
 [numpydoc standard]: https://numpydoc.readthedocs.io/en/latest/format.html


### PR DESCRIPTION
I found a dangling todo in the inline documentation section which should (I guess?) link to the writing documentation section. Ping me if it should have linked to the topical guide on writing documentation instead (they both have the same name).

You might want to check if the link works correctly. I have some ruby build issues locally and already spend too much time on it for a single line docs fix on a Sunday :) So i could not check it. 

Anyways, thanks for building this resource!
