### PR TITLE
fix: error if both target-version and project.requires-python are set

### DIFF
--- a/docs/pages/guides/repo_review.md
+++ b/docs/pages/guides/repo_review.md
@@ -18,7 +18,7 @@ fail, that's okay - the goal is bring all possible issues to your attention, not
 to force compliance with arbitrary checks.
 
 You can also run [this tool](https://github.com/scientific-python/repo-review)
-locally:
+locally (Python 3.10+ required):
 
 ```bash
 pipx run 'sp-repo-review[cli]' <path to repo>

--- a/src/sp_repo_review/checks/mypy.py
+++ b/src/sp_repo_review/checks/mypy.py
@@ -64,7 +64,8 @@ class MY102(MyPy):
     @staticmethod
     def check(pyproject: dict[str, Any]) -> bool:
         """
-        Must not have `show_error_codes`. Use `hide_error_codes` instead (since MyPy v0.990).
+        Must not have `show_error_codes`. It is now the default, or you can
+        use `hide_error_codes` with the reverse value instead (since MyPy v0.990).
         """
 
         match pyproject:

--- a/src/sp_repo_review/checks/ruff.py
+++ b/src/sp_repo_review/checks/ruff.py
@@ -66,20 +66,19 @@ class RF002(Ruff):
     "Target version must be set"
 
     @staticmethod
-    def check(pyproject: dict[str, Any], ruff: dict[str, Any]) -> bool:
+    def check(pyproject: dict[str, Any], ruff: dict[str, Any]) -> bool | str:
         """
         Must select a minimum version to target. Affects pyupgrade, isort, and
         others. Will be inferred from `project.requires-python`.
         """
 
-        if "target-version" in ruff:
-            return True
-
         match pyproject:
             case {"project": {"requires-python": str()}}:
+                if "target-version" in ruff:
+                    return "You have both Ruff's `target-version` and `project.requires-python`. You only need the later."
                 return True
             case _:
-                return False
+                return "target-version" in ruff
 
 
 class RF003(Ruff):


### PR DESCRIPTION
Small improvement for unneeded config.
