### PR TITLE
ci: keep github actions alive

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,15 @@
+name: keep-github-actions-alive
+on:
+  schedule:
+    - cron: "0 0 * * *"
+permissions:
+  actions: write
+jobs:
+  keep-alive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v2
+        with:
+          time_elapsed: 50
+          use_api: true


### PR DESCRIPTION
Github actions are automatically disabled when a repo is inactive for 60 days. To remedy this, there is a github action gautamkrishnar/keepalive-workflow@v2. The action uses GitHub API to reenable github actions in a repo.