### PR TITLE
Revert "ci: copier pyyaml-include issue"

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Install `copier` and `copier-templates-extensions`. Using [pipx][], that's:
 
 ```bash
 pipx install copier
-pipx inject copier copier-templates-extensions 'pyyaml-include<2'
+pipx inject copier copier-templates-extensions
 ```
 
 Now, run copier to generate your project:

--- a/noxfile.py
+++ b/noxfile.py
@@ -321,9 +321,7 @@ def nox_session(session: nox.Session, backend: str, vcs: bool) -> None:
 
 @nox.session()
 def compare_copier(session):
-    session.install(
-        "cookiecutter", "copier", "copier-templates-extensions", "pyyaml-include<2"
-    )
+    session.install("cookiecutter", "copier", "copier-templates-extensions")
 
     tmp_dir = session.create_tmp()
     session.cd(tmp_dir)


### PR DESCRIPTION
Reverts scientific-python/cookie#399

Fixed three days ago in copier.