### PR TITLE
fix: support macos-14, avoid macos-latest

### DIFF
--- a/.github/workflows/reusable-cookie.yml
+++ b/.github/workflows/reusable-cookie.yml
@@ -25,11 +25,15 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.12"]
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest, windows-latest]
 
         include:
           - python-version: pypy-3.9
             runs-on: ubuntu-latest
+          - python-version: "3.8"
+            runs-on: macos-13
+          - python-version: "3.12"
+            runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable-rr-tests.yml
+++ b/.github/workflows/reusable-rr-tests.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12-dev"]
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+        runs-on: [ubuntu-latest, macos-14, windows-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -43,11 +43,15 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.12"]
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest, windows-latest]
 
         include:
-          - python-version: pypy-3.10
+          - python-version: "pypy-3.10"
             runs-on: ubuntu-latest
+          - python-version: "3.8"
+            runs-on: macos-13
+          - python-version: "3.12"
+            runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4

--- a/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type=='compiled' %}cd.yml{% endif %}
+++ b/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type=='compiled' %}cd.yml{% endif %}
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -122,6 +122,7 @@ pytest-cov = { version = ">=3", optional = true }
 sphinx = { version = ">=7.0", optional = true }
 sphinx_copybutton = { version = ">=0.3.0", optional = true }
 sphinx-autodoc-typehints = { version = "*", optional = true }
+docutils = { version = "!=0.21.1", optional = true }
 
 [tool.poetry.dev-dependencies]
 pytest = ">= 6"
@@ -136,6 +137,7 @@ docs = [
   "sphinx",
   "sphinx_autodoc_typehints",
   "sphinx_copybutton",
+  "docutils",
 ]
 
 {%- if cookiecutter.vcs %}

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -297,7 +297,6 @@ write_to = "src/{{ cookiecutter.__project_slug }}/_version.py"
 [tool.cibuildwheel]
 test-command = "pytest {project}/tests"
 test-extras = ["test"]
-test-skip = ["*universal2:arm64"]
 {%- endif %}
 
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -122,7 +122,7 @@ pytest-cov = { version = ">=3", optional = true }
 sphinx = { version = ">=7.0", optional = true }
 sphinx_copybutton = { version = ">=0.3.0", optional = true }
 sphinx-autodoc-typehints = { version = "*", optional = true }
-docutils = { version = "!=0.21post1", optional = true }
+docutils = { version = "!=0.21.post1", optional = true }
 
 [tool.poetry.dev-dependencies]
 pytest = ">= 6"

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -122,7 +122,7 @@ pytest-cov = { version = ">=3", optional = true }
 sphinx = { version = ">=7.0", optional = true }
 sphinx_copybutton = { version = ">=0.3.0", optional = true }
 sphinx-autodoc-typehints = { version = "*", optional = true }
-docutils = { version = "!=0.21.1", optional = true }
+docutils = { version = "!=0.21post1", optional = true }
 
 [tool.poetry.dev-dependencies]
 pytest = ">= 6"


### PR DESCRIPTION
macos-latest now points to macos-14, which is ARM and doesn't have Python 3.8 and 3.9.
