### PR TITLE
ci: use macos-14's new Python 3.8+ support

### DIFF
--- a/.github/workflows/reusable-cookie.yml
+++ b/.github/workflows/reusable-cookie.yml
@@ -25,15 +25,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.12"]
-        runs-on: [ubuntu-latest, windows-latest]
+        runs-on: [ubuntu-latest, windows-latest, macos-14]
 
         include:
           - python-version: pypy-3.9
             runs-on: ubuntu-latest
-          - python-version: "3.8"
-            runs-on: macos-13
-          - python-version: "3.12"
-            runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4

--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -43,15 +43,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.12"]
-        runs-on: [ubuntu-latest, windows-latest]
+        runs-on: [ubuntu-latest, windows-latest, macos-14]
 
         include:
           - python-version: "pypy-3.10"
             runs-on: ubuntu-latest
-          - python-version: "3.8"
-            runs-on: macos-13
-          - python-version: "3.12"
-            runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Just released.
