### PR TITLE
remove template variables from apache license appendix

### DIFF
--- a/{{cookiecutter.project_name}}/{% if cookiecutter.license=='Apache' %}LICENSE{% endif %}
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.license=='Apache' %}LICENSE{% endif %}
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {{ cookiecutter.__year }} {{ cookiecutter.full_name }}
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
I believe the appendix is actually supposed to have the brackets there and no year+name substitution already done.

I think it might also be okay to omit the appendix? But better not if github includes it by default

Close #428 