### PR TITLE
falsey → falsy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,11 @@ repos:
         language: pygrep
         entry: PyBind|Numpy|Cmake|CCache|Github|PyTest|RST
         exclude: (.pre-commit-config.yaml|docs/pages/guides/style\.md)$
+      - id: disallow-words
+        name: Disallow certain words
+        language: pygrep
+        entry: '[Ff]alsey'
+        exclude: .pre-commit-config.yaml$
       - id: disallow-bad-permalinks
         name: Disallow _ in permalinks
         language: pygrep

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
       - id: disallow-words
         name: Disallow certain words
         language: pygrep
-        entry: '[Ff]alsey'
+        entry: "[Ff]alsey"
         exclude: .pre-commit-config.yaml$
       - id: disallow-bad-permalinks
         name: Disallow _ in permalinks

--- a/src/sp_repo_review/checks/mypy.py
+++ b/src/sp_repo_review/checks/mypy.py
@@ -163,7 +163,7 @@ class MY106(MyPy):
     def check(pyproject: dict[str, Any]) -> bool:
         """
         Must have `"truthy-bool"` in `enable_error_code = []`. This catches
-        mistakes in using a value as truthy if it cannot be falsey.
+        mistakes in using a value as truthy if it cannot be falsy.
 
         ```toml
         [tool.mypy]


### PR DESCRIPTION
Both look acceptable, but falsy is is more common than falsey, especially in contemporary English:
https://books.google.com/ngrams/graph?content=falsy%2Cfalsey&year_start=1800&year_end=2019&corpus=en-2019