### PR TITLE
Remove `ref-names` from `.git_archival.txt`

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,4 +1,3 @@
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
-ref-names: $Format:%D$

--- a/docs/pages/guides/packaging_classic.md
+++ b/docs/pages/guides/packaging_classic.md
@@ -222,7 +222,6 @@ You should also add these two files:
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
-ref-names: $Format:%D$
 ```
 
 And `.gitattributes` (or add this line if you are already using this file):

--- a/docs/pages/guides/packaging_simple.md
+++ b/docs/pages/guides/packaging_simple.md
@@ -145,7 +145,6 @@ You should also add these two files:
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
-ref-names: $Format:%D$
 ```
 
 And `.gitattributes` (or add this line if you are already using this file):

--- a/{{cookiecutter.project_name}}/.git_archival.txt
+++ b/{{cookiecutter.project_name}}/.git_archival.txt
@@ -1,4 +1,3 @@
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
-ref-names: $Format:%D$


### PR DESCRIPTION
Howdy! @webknjaz recently posted about this issue with `ref-names` on a package I maintain, so I thought I’d also submit a change the recommendations/instructions/templates here (where I think I originally learned about `.git_archival.txt`).

It turns out that the `ref-names` field in `.git_archival.txt` will generate a different value depending on whether the commit that an archive was built from was the head of a branch *at the time of archiving.* That's a problem because it means someone trying to compare the hash digests of two archives built from the same commit might get different results based on *when* the archives were made, and not on any other intrinsic feature of the archives' content (e.g. if I wanted to verify a published archive from an official release of a package against an archive I made the package’s git repo, I might get a different hash). This removes the field in order to make Git archives a bit more stable and useful.

There’s some discussion and detail in setuptools-scm’s repo at: https://github.com/pypa/setuptools_scm/issues/806. In particular, this comment about Arch Linux packaging was pretty convincing for me that this is an issue: https://github.com/pypa/setuptools_scm/issues/806#issuecomment-2053967913