### PR TITLE
fix: allow mdformat as a mdformatter

### DIFF
--- a/src/sp_repo_review/checks/precommit.py
+++ b/src/sp_repo_review/checks/precommit.py
@@ -130,6 +130,7 @@ class PC180(PreCommit):
     repos = {
         "https://github.com/pre-commit/mirrors-prettier",
         "https://github.com/rbubley/mirrors-prettier",
+        "https://github.com/executablebooks/mdformat",
     }
 
 


### PR DESCRIPTION
I'm a little worried about the development (hasn't been touched in months), and I don't like the plugin system not letting you list plugins, but I think it's fine if someone uses it, so adding it to the checks. If some of my concerns are addressed, then we could add it as a suggested alternative in the future.
