### PR TITLE
fix: allow pytest opts to be a string

### DIFF
--- a/src/sp_repo_review/checks/pyproject.py
+++ b/src/sp_repo_review/checks/pyproject.py
@@ -217,7 +217,10 @@ class PP308(PyProject):
         ```
         """
         options = pyproject["tool"]["pytest"]["ini_options"]
-        return any(opt.startswith("-r") for opt in options.get("addopts", []))
+        addopts = options.get("addopts", [])
+        if isinstance(addopts, str):
+            addopts = addopts.split()
+        return any(opt.startswith("-r") for opt in addopts)
 
 
 class PP309(PyProject):

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -92,3 +92,35 @@ def test_PP302_too_low():
         minversion = "5"
         """)
     assert not compute_check("PP302", pyproject=toml).result
+
+
+def test_PP308_list_okay():
+    toml = toml_loads("""
+        [tool.pytest.ini_options]
+        addopts = ["-ra"]
+        """)
+    assert compute_check("PP308", pyproject=toml).result
+
+
+def test_PP308_list_missing():
+    toml = toml_loads("""
+        [tool.pytest.ini_options]
+        addopts = ["-otther"]
+        """)
+    assert not compute_check("PP308", pyproject=toml).result
+
+
+def test_PP308_string_okay():
+    toml = toml_loads("""
+        [tool.pytest.ini_options]
+        addopts = "--stuff -ra --morestuff"
+        """)
+    assert compute_check("PP308", pyproject=toml).result
+
+
+def test_PP308_string_missing():
+    toml = toml_loads("""
+        [tool.pytest.ini_options]
+        addopts = "--stuff --morestuff"
+        """)
+    assert not compute_check("PP308", pyproject=toml).result


### PR DESCRIPTION
Fix https://github.com/scientific-python/cookie/issues/465 by allowing this to be a string. Pytest just transforms arrays into strings (same way cibuildwheel works, actually), so either is supported; reflect this in the check. The other checks look fine, and should support a string due to the way `in` works.
