### PR TITLE
fix: support for Ruff 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ for family, grp in itertools.groupby(collected.checks.items(), key=lambda x: x[1
 ### Ruff
 - [`RF001`](https://learn.scientific-python.org/development/guides/style#RF001): Has Ruff config
 - [`RF002`](https://learn.scientific-python.org/development/guides/style#RF002): Target version must be set
-- [`RF003`](https://learn.scientific-python.org/development/guides/style#RF003): src directory specified if used
+- [`RF003`](https://learn.scientific-python.org/development/guides/style#RF003): src directory doesn't need to be specified anymore (0.6+)
 - [`RF101`](https://learn.scientific-python.org/development/guides/style#RF101): Bugbear must be selected
 - [`RF102`](https://learn.scientific-python.org/development/guides/style#RF102): isort must be selected
 - [`RF103`](https://learn.scientific-python.org/development/guides/style#RF103): pyupgrade must be selected

--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -213,9 +213,6 @@ inspect and undo changes in git.
 {% rr RF001 %} Ruff is configured in your `pyproject.toml`. Here's an example:
 
 ```toml
-[tool.ruff]
-src = ["src"]
-
 [tool.ruff.lint]
 extend-select = [
   "B",        # flake8-bugbear
@@ -263,15 +260,16 @@ ignore certain error codes via `ignore`. You can also set codes per paths to
 ignore in `per-file-ignores`. If you don't like certain auto-fixes, you can
 disable auto-fixing for specific error codes via `unfixable`.
 
-There are other configuration options, such as the `src` list which tells it
-where to look for top level packages (mostly for "I" codes, which also have a
-lot of custom configuration options) {% rr RF003 %}, `typing-modules`, which
-helps apply typing-specific rules to a re-exported typing module (a common
-practice for unifying typing and `typing_extensions` based on Python version).
-There's also a file `exclude` set, which you can override if you are running
-this entirely from pre-commit (default excludes include "build", so if you have
-a `build` module or file named `build.py`, it would get skipped by default
-without this).
+There are other configuration options, such as `typing-modules`, which helps
+apply typing-specific rules to a re-exported typing module (a common practice
+for unifying typing and `typing_extensions` based on Python version). There's
+also a file `exclude` set, which you can override if you are running this
+entirely from pre-commit (default excludes include "build", so if you have a
+`build` module or file named `build.py`, it would get skipped by default without
+this).
+
+The `src` list which tells it where to look for top level packages is no longer
+needed if just set to `["src"]` in Ruff 0.6+. {% rr RF003 %}
 
 {: .warning }
 
@@ -874,9 +872,9 @@ And you can add this to your GitHub Actions using
 
 ### Ruff
 
-Ruff natively supports notebooks. You have to enable checking `.ipynb` files in
-pre-commit to use it with `types_or: [python, pyi, jupyter]`. This should be on
-both hooks if using both the linter and the formatter.
+Ruff natively supports notebooks. You no longer need to enable it, it's on by
+default with Ruff 0.6+. If you want to control rules based on being notebooks,
+you can just match with `**.ipynb` like any other file.
 
 ### Black
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,9 +139,6 @@ messages_control.disable = [
 ]
 
 
-[tool.ruff]
-src = ["src"]
-
 [tool.ruff.lint]
 extend-select = [
   "B",           # flake8-bugbear

--- a/src/sp_repo_review/checks/ruff.py
+++ b/src/sp_repo_review/checks/ruff.py
@@ -85,26 +85,24 @@ class RF002(Ruff):
 
 
 class RF003(Ruff):
-    "src directory specified if used"
+    "src directory doesn't need to be specified anymore (0.6+)"
 
     @staticmethod
     def check(ruff: dict[str, Any], package: Traversable) -> bool | None:
         """
-        Must specify `src` directory if it exists.
-
-        ```toml
-        [tool.ruff]
-        src = ["src"]
-        ```
+        Ruff now (0.6+) looks in the src directory by default. The src setting
+        doesn't need to be specified if it's just set to `["src"]`.
         """
+
         if not package.joinpath("src").is_dir():
             return None
 
         match ruff:
-            case {"src": list(x)}:
-                return "src" in x
+            case {"src": ["src"]}:
+                # See https://github.com/python/mypy/issues/16272
+                return False  # type: ignore[unreachable]
             case _:
-                return False
+                return True
 
 
 class RF1xxMixin(Protocol):


### PR DESCRIPTION
Flips this check now that Ruff defaults to `["src"]`. Also update docs on Jupyter notebooks and Ruff, since that's now default.
