### PR TITLE
fix: support .yaml for dependabot too

### DIFF
--- a/src/sp_repo_review/checks/github.py
+++ b/src/sp_repo_review/checks/github.py
@@ -25,11 +25,16 @@ def workflows(root: Traversable) -> dict[str, Any]:
 
 
 def dependabot(root: Traversable) -> dict[str, Any]:
-    dependabot_path = root.joinpath(".github/dependabot.yml")
-    if dependabot_path.is_file():
-        with dependabot_path.open("rb") as f:
-            result: dict[str, Any] = yaml.safe_load(f)
-            return result
+    dependabot_paths = [
+        root.joinpath(".github/dependabot.yml"),
+        root.joinpath(".github/dependabot.yaml"),
+    ]
+
+    for dependabot_path in dependabot_paths:
+        if dependabot_path.is_file():
+            with dependabot_path.open("rb") as f:
+                result: dict[str, Any] = yaml.safe_load(f)
+                return result
 
     return {}
 


### PR DESCRIPTION
Fix #485. Both names seem to be supported. Hopefully I got the order correct, but someone shouldn't have both anyway. :)
