### PR TITLE
chore: support uv run

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -285,6 +285,18 @@ write_to = "src/{{ cookiecutter.__project_slug }}/_version.py"
 {%- endif %}
 
 
+{%- if cookiecutter.backend not in ["setuptools", "pybind11", "poetry", "whey"] %}
+
+
+[tool.uv]
+dev-dependencies = [
+  "{{ cookiecutter.__project_slug }}[test]",
+]
+
+
+{%- endif %}
+
+
 {%- if cookiecutter.__type == "compiled" %}
 
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -285,7 +285,7 @@ write_to = "src/{{ cookiecutter.__project_slug }}/_version.py"
 {%- endif %}
 
 
-{%- if cookiecutter.backend not in ["setuptools", "pybind11", "poetry", "whey"] %}
+{%- if cookiecutter.backend not in ["setuptools", "pybind11", "poetry"] %}
 
 
 [tool.uv]


### PR DESCRIPTION
This makes `uv run pytest` or `uv run --python 3.13 pytest` work out of the box.
