### PR TITLE
fix: don't set license.file

### DIFF
--- a/docs/_includes/pyproject.md
+++ b/docs/_includes/pyproject.md
@@ -7,7 +7,6 @@ The metadata is specified in a [standards-based][metadata] format:
 name = "package"
 description = "A great package."
 readme = "README.md"
-license.file = "LICENSE"
 authors = [
   { name = "My Name", email = "me@email.com" },
 ]

--- a/docs/pages/guides/packaging_simple.md
+++ b/docs/pages/guides/packaging_simple.md
@@ -189,6 +189,11 @@ This is tool specific.
 > unzip -l dist/*.whl
 > ```
 
+{: .note-title }
+
+> Flit _requires_ `license.file` to be set in your `[project]` section to ensure
+> it finds the license file.
+
 <!-- prettier-ignore-start -->
 
 [flit]: https://flit.readthedocs.io

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -142,7 +142,7 @@ maintainers = [
 {%- endif %}
 description = "{{ cookiecutter.project_short_description }}"
 readme = "README.md"
-{%- if cookiecutter.backend in ['flit-coverage', 'mesonpy'] %}
+{%- if cookiecutter.backend in ['flit', 'mesonpy'] %}
 license.file = "LICENSE"
 {%- endif %}
 requires-python = ">=3.9"

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -142,7 +142,9 @@ maintainers = [
 {%- endif %}
 description = "{{ cookiecutter.project_short_description }}"
 readme = "README.md"
+{%- if cookiecutter.backend in ['flit-coverage', 'mesonpy'] %}
 license.file = "LICENSE"
+{%- endif %}
 requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 1 - Planning",


### PR DESCRIPTION
This doesn't work correctly, it sets the License metadata field, which is supposed to describe the deviation from the classifiers, not contain a whole license. PEP 639 finally fixes this using SPDX classifiers.
