### PR TITLE
chore: remove a few more references to Python 3.8

### DIFF
--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -277,7 +277,7 @@ needed if just set to `["src"]` in Ruff 0.6+. {% rr RF003 %}
 > should also set:
 >
 > ```toml
-> target-version = "py38"
+> target-version = "py39"
 > ```
 >
 > This selects the minimum version you want to target (primarily for `"UP"` and
@@ -491,7 +491,7 @@ when clearly better (please always use them, they are faster) if you set
   rev: "v3.18.0"
   hooks:
     - id: pyupgrade
-      args: ["--py38-plus"]
+      args: ["--py39-plus"]
 ```
 
 [pyupgrade]: https://github.com/asottile/pyupgrade

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -324,7 +324,7 @@ disallow_incomplete_defs = true
 
 [tool.ruff]
 {%- if cookiecutter.backend == "poetry" %}
-target-version = "py38"
+target-version = "py39"
 {%- endif %}
 
 [tool.ruff.lint]

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.__ci=='gitlab' %}.gitlab-ci.yml{% endif %}
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.__ci=='gitlab' %}.gitlab-ci.yml{% endif %}
@@ -121,7 +121,7 @@ make_wheels:
       entrypoint: ["env", "-u", "DOCKER_HOST"]
       command: ["dockerd-entrypoint.sh"]
   matrix:
-    - CIBW_BUILD: ['cp38-*', 'cp39-*', 'cp310-*', 'cp311-*', 'cp312-*']
+    - CIBW_BUILD: ['cp39-*', 'cp310-*', 'cp311-*', 'cp312-*', 'cp313-*']
       CIBW_PLATFORM: ['linux', 'windows']  # 'macos' not supported by CIBW on GitLab CI
   variables:
     DOCKER_HOST: tcp://docker:2375/


### PR DESCRIPTION
Missed these earlier.
