### PR TITLE
bugfix: Stricter check for "tests" and "docs" directories in sp-repo-review 

### DIFF
--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -77,9 +77,18 @@ class PY005(General):
 
     @staticmethod
     def check(package: Traversable) -> bool:
-        "Projects must have a folder called `tests` or `src/*/tests`"
+        "Projects must have a folder called `test*` or `src/*/test*`"
         # Out-of-source tests
-        if len([p for p in package.iterdir() if p.is_dir() and p.name == "tests"]) > 0:
+        if (
+            len(
+                [
+                    p
+                    for p in package.iterdir()
+                    if p.is_dir() and p.name.startswith("test")
+                ]
+            )
+            > 0
+        ):
             return True
 
         # In-source tests
@@ -89,7 +98,11 @@ class PY005(General):
                 if (
                     pkg.is_dir()
                     and len(
-                        [p for p in pkg.iterdir() if p.is_dir() and p.name == "tests"]
+                        [
+                            p
+                            for p in pkg.iterdir()
+                            if p.is_dir() and p.name.startswith("test")
+                        ]
                     )
                     > 0
                 ):

--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -65,7 +65,9 @@ class PY004(General):
     @staticmethod
     def check(package: Traversable) -> bool:
         "Projects must have documentation in a folder called docs (disable if not applicable)"
-        return len([p for p in package.iterdir() if p.is_dir() and p.name == "docs"]) > 0
+        return (
+            len([p for p in package.iterdir() if p.is_dir() and p.name == "docs"]) > 0
+        )
 
 
 class PY005(General):
@@ -86,7 +88,10 @@ class PY005(General):
             for pkg in src.iterdir():
                 if (
                     pkg.is_dir()
-                    and len([p for p in pkg.iterdir() if p.is_dir() and p.name == "tests"]) > 0
+                    and len(
+                        [p for p in pkg.iterdir() if p.is_dir() and p.name == "tests"]
+                    )
+                    > 0
                 ):
                     return True
         return False

--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -65,7 +65,7 @@ class PY004(General):
     @staticmethod
     def check(package: Traversable) -> bool:
         "Projects must have documentation in a folder called docs (disable if not applicable)"
-        return len([p for p in package.iterdir() if "doc" in p.name]) > 0
+        return len([p for p in package.iterdir() if p.is_dir() and p.name == "docs"]) > 0
 
 
 class PY005(General):

--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -75,9 +75,9 @@ class PY005(General):
 
     @staticmethod
     def check(package: Traversable) -> bool:
-        "Projects must have a folder called `*test*` or `src/*/*test*`"
+        "Projects must have a folder called `tests` or `src/*/tests`"
         # Out-of-source tests
-        if len([p for p in package.iterdir() if "test" in p.name]) > 0:
+        if len([p for p in package.iterdir() if p.is_dir() and p.name == "tests"]) > 0:
             return True
 
         # In-source tests
@@ -86,7 +86,7 @@ class PY005(General):
             for pkg in src.iterdir():
                 if (
                     pkg.is_dir()
-                    and len([p for p in pkg.iterdir() if "test" in p.name]) > 0
+                    and len([p for p in pkg.iterdir() if p.is_dir() and p.name == "tests"]) > 0
                 ):
                     return True
         return False

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -54,6 +54,13 @@ def test_py004(tmp_path: Path):
     assert compute_check("PY004", package=simple).result
 
 
+def test_py004_not_dir(tmp_path: Path):
+    simple = tmp_path / "simple"
+    simple.mkdir()
+    simple.joinpath("docs")
+    assert not compute_check("PY004", package=simple).result
+
+
 def test_py004_missing(tmp_path: Path):
     simple = tmp_path / "simple"
     simple.mkdir()
@@ -65,6 +72,34 @@ def test_py005(tmp_path: Path):
     simple.mkdir()
     simple.joinpath("tests").mkdir()
     assert compute_check("PY005", package=simple).result
+
+
+def test_py005_alt_singular(tmp_path: Path):
+    simple = tmp_path / "simple"
+    simple.mkdir()
+    simple.joinpath("test").mkdir()
+    assert compute_check("PY005", package=simple).result
+
+
+def test_py005_alt_integration(tmp_path: Path):
+    simple = tmp_path / "simple"
+    simple.mkdir()
+    simple.joinpath("tests-integration").mkdir()
+    assert compute_check("PY005", package=simple).result
+
+
+def test_py005_not_folder(tmp_path: Path):
+    simple = tmp_path / "simple"
+    simple.mkdir()
+    simple.joinpath("tests")
+    assert not compute_check("PY005", package=simple).result
+
+
+def test_py005_not_tests(tmp_path: Path):
+    simple = tmp_path / "simple"
+    simple.mkdir()
+    simple.joinpath("fastest").mkdir()
+    assert not compute_check("PY005", package=simple).result
 
 
 def test_py005_missing(tmp_path: Path):

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -80,7 +80,7 @@ def test_py005_src(tmp_path: Path):
     src.mkdir()
     pkg = src.joinpath("pkg")
     pkg.mkdir()
-    pkg.joinpath("test").mkdir()
+    pkg.joinpath("tests").mkdir()
     assert compute_check("PY005", package=simple).result
 
 


### PR DESCRIPTION
### Summary
The `sp-repo-review` checks for the existence of the `tests` (PY005) and `docs` (PY004) directories are too lenient and often return false positives.

### Details
The existence of a file or directory in the repo that _contains_ the word "docs" or "tests" will result in a pass for these tests.

For example, the existence of the `.readthedocs` file causes the `PY004 Has docs folder` test to pass, simply because it contains the work `docs`. Similarly, an innocuously named file such as `fastest.txt` would result in a false pass of `PY005 Has tests folder`.

This PR modifies the `PY004` and `PY005` checks to:
- Compare against string `tests` or `docs`, rather than testing if the filename contains that string.
- Require that the path is a directory
- `test` is no longer a match for PY005: should be `tests` as per [Scientific Python: package-structure](https://learn.scientific-python.org/development/guides/packaging-simple/#package-structure);  this required an update to the internal tests.