### PR TITLE
ISC rules do not conflict with the formatter anymore

### DIFF
--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -245,7 +245,6 @@ extend-select = [
 ignore = [
   "PLR09",    # Too many <...>
   "PLR2004",  # Magic value used in comparison
-  "ISC001",   # Conflicts with formatter
 ]
 typing-modules = ["mypackage._compat.typing"]
 isort.required-imports = ["from __future__ import annotations"]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -371,7 +371,6 @@ extend-select = [
 ignore = [
   "PLR09",    # Too many <...>
   "PLR2004",  # Magic value used in comparison
-  "ISC001",   # Conflicts with formatter
 ]
 isort.required-imports = ["from __future__ import annotations"]
 # Uncomment if using a _compat.typing backport


### PR DESCRIPTION
Starting with ruff 0.9.0, ruff rule [`ISC001`](https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/) is compatible with the ruff formatter:
* https://astral.sh/blog/ruff-v0.9.0#fewer-single-line-implicitly-concatenated-strings
* https://github.com/astral-sh/ruff/pull/15123

As for [`ISC002`](https://docs.astral.sh/ruff/rules/multi-line-implicit-string-concatenation/):
> ### Formatter compatibility
> 
> Using this rule with `allow-multiline = false` can be incompatible with the formatter because the [formatter](https://docs.astral.sh/ruff/formatter/) can introduce new multi-line implicitly concatenated strings. We recommend to either:
> * Enable `ISC001` to disallow all implicit concatenated strings
> * Setting `allow-multiline = true`