### PR TITLE
fix: use -e in more places in the noxfile

### DIFF
--- a/docs/pages/guides/tasks.md
+++ b/docs/pages/guides/tasks.md
@@ -212,7 +212,7 @@ def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.
     """
-    session.install(".[test]")
+    session.install("-e.[test]")
     session.run("pytest", *session.posargs)
 ```
 <!-- prettier-ignore-end -->

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -31,7 +31,7 @@ def pylint(session: nox.Session) -> None:
     """
     # This needs to be installed into the package environment, and is slower
     # than a pre-commit check
-    session.install("-e.", "pylint>=3.2")
+    session.install("{% if cookiecutter.backend != "mesonpy" %}-e{% endif %}.", "pylint>=3.2")
     session.run("pylint", "{{ cookiecutter.__project_slug }}", *session.posargs)
 
 
@@ -40,7 +40,7 @@ def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.
     """
-    session.install("-e.[test]")
+    session.install("{% if cookiecutter.backend != "mesonpy" %}-e{% endif %}.[test]")
     session.run("pytest", *session.posargs)
 
 
@@ -58,7 +58,7 @@ def docs(session: nox.Session) -> None:
     args, posargs = parser.parse_known_args(session.posargs)
     serve = args.builder == "html" and session.interactive
 
-    session.install("-e.[docs]", "sphinx-autobuild")
+    session.install("{% if cookiecutter.backend != "mesonpy" %}-e{% endif %}.[docs]", "sphinx-autobuild")
 
     shared_args = (
         "-n",  # nitpicky mode

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -31,7 +31,7 @@ def pylint(session: nox.Session) -> None:
     """
     # This needs to be installed into the package environment, and is slower
     # than a pre-commit check
-    session.install(".", "pylint>=3.2")
+    session.install("-e.", "pylint>=3.2")
     session.run("pylint", "{{ cookiecutter.__project_slug }}", *session.posargs)
 
 
@@ -40,7 +40,7 @@ def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.
     """
-    session.install(".[test]")
+    session.install("-e.[test]")
     session.run("pytest", *session.posargs)
 
 


### PR DESCRIPTION
See #566. Let see if any backends have issues. We already had it in the docs job, and the one backend I know about that it used to not work should be removed now. Edit: Looks like mesonpy doesn't handle editable installs very well, that's the blocker.