### PR TITLE
Rename PyLint -> Pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
       - id: disallow-caps
         name: Disallow improper capitalization
         language: pygrep
-        entry: PyBind|Numpy|Cmake|CCache|Github|PyTest|RST
+        entry: PyBind|Numpy|Cmake|CCache|Github|PyTest|RST|PyLint
         exclude: (.pre-commit-config.yaml|docs/pages/guides/style\.md)$
       - id: disallow-words
         name: Disallow certain words

--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -306,7 +306,7 @@ Here are some good error codes to enable on most (but not all!) projects:
 - `PGH`: Checks for patterns, such as type ignores or noqa's without a specific
   error code.
 - `PL`: A set of four code groups that cover some (200 or so out of 600 rules)
-  of PyLint.
+  of Pylint.
 - `PT`: Helps tests follow best pytest practices. A few codes are not ideal, but
   many are helpful.
 - `PTH`: Want to move to using modern pathlib? This will help. There are some
@@ -829,12 +829,12 @@ schemas, and you can load them via URL. It work on JSON, YAML, and TOML.
     - id: check-readthedocs
 ```
 
-## PyLint (noisy)
+## Pylint (noisy)
 
-PyLint is very opinionated, with a high signal-to-noise ratio. However, by
+Pylint is very opinionated, with a high signal-to-noise ratio. However, by
 limiting the default checks or by starting off a new project using them, you can
 get some very nice linting, including catching some problematic code that
-otherwise is hard to catch. PyLint is generally not a good candidate for
+otherwise is hard to catch. Pylint is generally not a good candidate for
 pre-commit, since it needs to have your package installed - it is less static of
 check than Ruff or Flake8. Here is a suggested `pyproject.toml` entry to get you
 started:

--- a/noxfile.py
+++ b/noxfile.py
@@ -505,7 +505,7 @@ def rr_lint(session: nox.Session) -> None:
 @nox.session
 def rr_pylint(session: nox.Session) -> None:
     """
-    Run PyLint.
+    Run Pylint.
     """
     # This needs to be installed into the package environment, and is slower
     # than a pre-commit check

--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --hook-stage manual --all-files
-      - name: Run PyLint
+      - name: Run Pylint
         run: pipx run nox -s pylint -- --output-format=github
 
   checks:

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -27,7 +27,7 @@ def lint(session: nox.Session) -> None:
 @nox.session
 def pylint(session: nox.Session) -> None:
     """
-    Run PyLint.
+    Run Pylint.
     """
     # This needs to be installed into the package environment, and is slower
     # than a pre-commit check


### PR DESCRIPTION
I think they style themselves as Pylint or pylint - see https://github.com/pylint-dev/pylint or https://pylint.readthedocs.io/en/latest/
> What is Pylint?
