### PR TITLE
chore: use uv and dependency-groups

### DIFF
--- a/.github/workflows/reusable-rr-tests.yml
+++ b/.github/workflows/reusable-rr-tests.yml
@@ -28,11 +28,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
-      - name: Install package
-        run: python -m pip install .[test,cli]
+      - uses: astral-sh/setup-uv@v6
 
       - name: Test package
-        run: python -m pytest -ra
+        run: uv run pytest -ra
         env:
           PYTHONWARNDEFAULTENCODING: 1
 
@@ -57,11 +56,13 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
+
+      - uses: astral-sh/setup-uv@v6
 
       - name: Rerender README
         run: |
-          pipx run nox -s readme
+          uvx nox -s readme
           git diff --exit-code
 
   pylint:
@@ -72,5 +73,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - uses: astral-sh/setup-uv@v6
+
       - name: Run pylint
-        run: pipx run nox[uv] -s rr_pylint -- --output-format=github
+        run: uvx nox -s rr_pylint -- --output-format=github

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Review repos for compliance to the Scientific-Python development guidelines"
 requires-python = ">=3.10"
-license-expression = 'BSD-3-Clause'
+license = 'BSD-3-Clause'
 classifiers = [
   "Development Status :: 4 - Beta",
   "Environment :: Console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,13 +40,6 @@ dependencies = [
 cli = [
   "repo-review[cli]",
 ]
-test = [
-  "pytest >=7",
-  "repo-review >=0.10.6",
-]
-dev = [
-  "pytest >=7",
-]
 pyproject = [
   "validate-pyproject-schema-store[all]",
 ]
@@ -82,6 +75,16 @@ setupcfg = "sp_repo_review.checks.setupcfg:setupcfg"
 [project.entry-points."repo_review.families"]
 scikit-hep = "sp_repo_review.families:get_families"
 
+[dependency-groups]
+dev = [
+  { include-group = "test" },
+  "repo-review[cli]",
+  "validate-pyproject-schema-store[all]",
+]
+test = [
+  "pytest >=7",
+  "repo-review >=0.10.6",
+]
 
 [tool.hatch]
 version.source = "vcs"


### PR DESCRIPTION
Pip 25.1 supports `--group` now too, so starting to transition here. First moving sp-repo-review.
