### PR TITLE
fix: detect SPDX licenses too

### DIFF
--- a/src/sp_repo_review/families.py
+++ b/src/sp_repo_review/families.py
@@ -18,7 +18,9 @@ class Family(typing.TypedDict, total=False):
 
 def get_families(pyproject: dict[str, Any]) -> dict[str, Family]:
     pyproject_description = f"- Detected build backend: `{pyproject.get('build-system', {}).get('build-backend', 'MISSING')}`"
-    if classifiers := pyproject.get("project", {}).get("classifiers", []):
+    if isinstance(license := pyproject.get("project", {}).get("license", {}), str):
+        pyproject_description += f"\n- SPDX license expression: `{license}`"
+    elif classifiers := pyproject.get("project", {}).get("classifiers", []):
         licenses = [
             c.removeprefix("License :: ").removeprefix("OSI Approved :: ")
             for c in classifiers

--- a/tests/test_families.py
+++ b/tests/test_families.py
@@ -1,0 +1,47 @@
+from sp_repo_review.families import get_families
+
+
+def test_backend():
+    pyproject = {
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    }
+    families = get_families(pyproject)
+    assert families["general"].get("description") == (
+        "- Detected build backend: `setuptools.build_meta`"
+    )
+
+
+def test_spdx_license():
+    pyproject = {
+        "project": {
+            "license": "MIT",
+            "classifiers": [
+                "License :: OSI Approved :: MIT License",
+                "License :: OSI Approved :: BSD License",
+            ],
+        },
+    }
+    families = get_families(pyproject)
+    assert families["general"].get("description") == (
+        "- Detected build backend: `MISSING`\n- SPDX license expression: `MIT`"
+    )
+
+
+def test_classic_license():
+    pyproject = {
+        "project": {
+            "license": {"text": "Free-form"},
+            "classifiers": [
+                "License :: OSI Approved :: MIT License",
+                "License :: OSI Approved :: BSD License",
+            ],
+        },
+    }
+    families = get_families(pyproject)
+    assert families["general"].get("description") == (
+        "- Detected build backend: `MISSING`\n"
+        "- Detected license(s): MIT License, BSD License"
+    )


### PR DESCRIPTION
Support PEP 639 in the license detection.
