### PR TITLE
feat: use PEP 639 where possible

### DIFF
--- a/docs/_includes/pyproject.md
+++ b/docs/_includes/pyproject.md
@@ -50,9 +50,11 @@ or [Whey](https://whey.readthedocs.io/en/latest/configuration.html). Note that
 
 The license can be done one of two ways.
 
-The modern way is
-to use the `license` field and an [SPDX identifier expression][spdx]. You can specify a list of files globs in `license-files`. Currently, `hatchling>=1.26`, `flit-core>=1.11`, `pdm-backend>=2.4`, `setuptools>=77`, and `scikit-build-core>=0.12` support this. Only `maturin`, `meson-python`,
-and `flit-core` do not support this yet.
+The modern way is to use the `license` field and an [SPDX identifier
+expression][spdx]. You can specify a list of files globs in `license-files`.
+Currently, `hatchling>=1.26`, `flit-core>=1.11`, `pdm-backend>=2.4`,
+`setuptools>=77`, and `scikit-build-core>=0.12` support this. Only `maturin`,
+`meson-python`, and `flit-core` do not support this yet.
 
 The classic convention uses one or more [Trove Classifiers][] to specify the
 license. There also was a `license.file` field, required by `meson-python`, but

--- a/docs/_includes/pyproject.md
+++ b/docs/_includes/pyproject.md
@@ -7,6 +7,8 @@ The metadata is specified in a [standards-based][metadata] format:
 name = "package"
 description = "A great package."
 readme = "README.md"
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 authors = [
   { name = "My Name", email = "me@email.com" },
 ]
@@ -21,7 +23,6 @@ dependencies = [
 
 classifiers = [
   "Development Status :: 4 - Beta",
-  "License :: OSI Approved :: BSD License",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -47,19 +48,26 @@ or [Whey](https://whey.readthedocs.io/en/latest/configuration.html). Note that
 
 ### License
 
-The license can be done one of two ways. The classic convention (shown above)
-uses one or more [Trove Classifiers][] to specify the license. The other way is
-to use the `license` field and an [SPDX identifier expression][spdx]:
+The license can be done one of two ways.
 
-```toml
-license = "BSD-3-Clause"
+The modern way is
+to use the `license` field and an [SPDX identifier expression][spdx]. You can specify a list of files globs in `license-files`. Currently, `hatchling>=1.26`, `flit-core>=1.11`, `pdm-backend>=2.4`, `setuptools>=77`, and `scikit-build-core>=0.12` support this. Only `maturin`, `meson-python`,
+and `flit-core` do not support this yet.
+
+The classic convention uses one or more [Trove Classifiers][] to specify the
+license. There also was a `license.file` field, required by `meson-python`, but
+other tools often did the wrong thing (such as load the entire file into the
+metadata's free-form one line text field that was intended to describe
+deviations from the classifier license(s)).
+
+```
+classifiers = [
+  "License :: OSI Approved :: BSD License",
+]
 ```
 
-You can also specify files to include with the `license-files` field.
-
 You should not include the `License ::` classifiers if you use the `license`
-field {% rr PP007 %}. Some backends do not support this fully yet (notably
-Poetry and Setuptools).
+field {% rr PP007 %}.
 
 ### Extras
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -282,6 +282,15 @@ def dist(session: nox.Session, backend: str, vcs: bool) -> None:
     # Check for LICENSE in SDist
     with tarfile.open(sdist) as tf:
         names = tf.getnames()
+        if backend not in {"mesonpy", "poetry", "maturin"}:
+            (metadata_path,) = (
+                n for n in names if n.endswith("PKG-INFO") and "egg-info" not in n
+            )
+            with tf.extractfile(metadata_path) as mfile:
+                info = mfile.read().decode("utf-8")
+                if "License-Expression: BSD-3-Clause" not in info:
+                    msg = "License expression not found in METADATA"
+                    session.error(msg)
     if not any(n.endswith("LICENSE") for n in names):
         msg = f"license file missing from {backend} vcs={vcs}'s sdist. Found: {names}"
         session.error(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Review repos for compliance to the Scientific-Python development guidelines"
 requires-python = ">=3.10"
-license = 'BSD-3-Clause'
+license = "BSD-3-Clause"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Environment :: Console",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -66,7 +66,16 @@ maintainers = [
 {%- endif %}
 description = "{{ cookiecutter.project_short_description }}"
 readme = "README.md"
-{%- if cookiecutter.backend in ['flit', 'mesonpy'] %}
+{%- if cookiecutter.backend not in ['poetry', 'mesonpy', 'maturin'] %}
+{%- if cookiecutter.license == "BSD" %}
+license = "BSD-3-Clause"
+{%- elif cookiecutter.license == "Apache" %}
+license = "Apache-2.0"
+{%- elif cookiecutter.license == "MIT" %}
+license = "MIT"
+{%- endif %}
+{%- endif %}
+{%- if cookiecutter.backend in ['mesonpy'] %}
 license.file = "LICENSE"
 {%- endif %}
 requires-python = ">=3.9"
@@ -74,12 +83,14 @@ classifiers = [
   "Development Status :: 1 - Planning",
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",
+{%- if cookiecutter.backend in ['poetry', 'mesonpy', 'maturin'] %}
 {%- if cookiecutter.license == "BSD" %}
   "License :: OSI Approved :: BSD License",
 {%- elif cookiecutter.license == "Apache" %}
   "License :: OSI Approved :: Apache Software License",
 {%- elif cookiecutter.license == "MIT" %}
   "License :: OSI Approved :: MIT License",
+{%- endif %}
 {%- endif %}
   "Operating System :: OS Independent",
   "Programming Language :: Python",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -1,41 +1,41 @@
 [build-system]
 {%- if cookiecutter.backend == "pdm" %}
-requires = ["pdm-backend"]
+requires = ["pdm-backend>=2.4"]
 build-backend = "pdm.backend"
 {%- elif cookiecutter.backend == "maturin" %}
 requires = ["maturin>=0.15,<2"]
 build-backend = "maturin"
 {%- elif cookiecutter.backend == "hatch" %}
 {%- if cookiecutter.vcs %}
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling>=1.26", "hatch-vcs"]
 {%- else %}
-requires = ["hatchling"]
+requires = ["hatchling>=1.26"]
 {%- endif %}
 build-backend = "hatchling.build"
 {%- elif cookiecutter.backend == "setuptools" %}
 {%- if cookiecutter.vcs %}
-requires = ["setuptools>=61", "setuptools_scm[toml]>=7"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=7"]
 {%- else %}
-requires = ["setuptools>=61"]
+requires = ["setuptools>=77"]
 {%- endif %}
 build-backend = "setuptools.build_meta"
 {%- elif cookiecutter.backend == "flit" %}
 {%- if cookiecutter.vcs %}
-requires = ["flit_scm"]
+requires = ["flit_scm", "flit_core>=3.11"]
 build-backend = "flit_scm:buildapi"
 {%- else %}
-requires = ["flit_core>=3.4"]
+requires = ["flit_core>=3.11"]
 build-backend = "flit_core.buildapi"
 {%- endif %}
 {%- elif cookiecutter.backend == "pybind11" %}
 {%- if cookiecutter.vcs %}
-requires = ["setuptools>=61", "setuptools_scm[toml]>=7", "pybind11"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=7", "pybind11"]
 {%- else %}
-requires = ["setuptools>=61", "pybind11"]
+requires = ["setuptools>=77", "pybind11"]
 {%- endif %}
 build-backend = "setuptools.build_meta"
 {%- elif cookiecutter.backend == "skbuild"  %}
-requires = ["pybind11", "scikit-build-core>=0.10"]
+requires = ["pybind11", "scikit-build-core>=0.11"]
 build-backend = "scikit_build_core.build"
 {%- elif cookiecutter.backend == "mesonpy" %}
 requires = ["meson-python", "pybind11"]


### PR DESCRIPTION
Supported:

* `hatchling>=1.26`
* `flit-core>=1.11`
* `pdm-backend>=2.4`
* `setuptools>=77`
* `scikit-build-core>=0.12`

Currently the only backends that haven't supported this yet:

* Maturin (in progress in https://github.com/PyO3/maturin/pull/2571)
* Meson-python (in https://github.com/mesonbuild/meson-python/pull/681, unreleased)
* Poetry-core (produces Metadata 2.3 when configured! Support issue: https://github.com/python-poetry/poetry/issues/9670)

Close #589.
