### PR TITLE
ci: add links to rendered docs

### DIFF
--- a/.github/workflows/docs-link.yml
+++ b/.github/workflows/docs-link.yml
@@ -1,0 +1,24 @@
+name: Read the Docs PR preview
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "scientific-python-cookie"
+          single-version: "true"


### PR DESCRIPTION
Not a huge fan of adding links when it's also in the checks list, but I want to test this out and for something that's mostly docs, it's not a bad idea.