### PR TITLE
fix: move codespell config to toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,9 @@ repos:
     hooks:
       - id: codespell
         exclude: ^Gemfile\.lock$
-        args: ["-Lnd", "-w"]
+        additional_dependencies:
+          - tomli; python_version<'3.11'
+        args: ["-w"]
 
   - repo: local
     hooks:

--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -672,8 +672,8 @@ than a list of "valid" words. To use:
 
 You can list allowed spellings in a comma separated string passed to `-L` (or
 `--ignore-words-list` - usually it is better to use long options when you are
-not typing things live). The example below will allow "Big Sur" and "ND".
-Here's an example of `pyproject.toml` configuration:
+not typing things live). The example below will allow "Big Sur" and "ND". Here's
+an example of `pyproject.toml` configuration:
 
 ```ini
 [tool.codespell]

--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -666,21 +666,23 @@ than a list of "valid" words. To use:
   rev: "v2.4.1"
   hooks:
     - id: codespell
-      args: ["-L", "sur,nd"]
+      additional_dependencies:
+        - tomli; python_version<'3.11'
 ```
 
 You can list allowed spellings in a comma separated string passed to `-L` (or
 `--ignore-words-list` - usually it is better to use long options when you are
-not typing things live). The example above will allow "Big Sur" and "ND". You
-can instead use a comma separated list in `setup.cfg` or `.codespellrc`:
+not typing things live). The example below will allow "Big Sur" and "ND".
+Here's an example of `pyproject.toml` configuration:
 
 ```ini
-[codespell]
-ignore-words-list = sur,nd
+[tool.codespell]
+ignore-words-list = ["sur", "nd"]
 ```
 
-If you add the `toml` extra (or use Python 3.11+), you can instead put a
-`tool.codespell` section in your `pyproject.toml`.
+You can also add the `-w` flag to have it automatically correct errors - this is
+very helpful to quickly make corrections if you have a lot of them when first
+adding the check. `uvx codespell -w` will quickly correct all non-hidden files.
 
 You can also use a local pygrep check to eliminate common capitalization errors,
 such as the one below:
@@ -694,10 +696,6 @@ such as the one below:
       entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
       exclude: .pre-commit-config.yaml
 ```
-
-You can also add the `-w` flag to have it automatically correct errors - this is
-very helpful to quickly make corrections if you have a lot of them when first
-adding the check.
 
 ## PyGrep hooks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,3 +188,8 @@ ignore = [
 
 [tool.repo-review.ignore]
 RTD103 = "Using Ruby instead of Python for docs"
+
+[tool.codespell]
+ignore-words-list = [
+  "nd",
+]

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -71,6 +71,8 @@ repos:
     rev: "v2.4.1"
     hooks:
       - id: codespell
+        additional_dependencies:
+          - tomli; python_version<'3.11'
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: "v0.10.0.1"


### PR DESCRIPTION
See https://github.com/pypa/packaging/pull/910.

We could add a check for this to sp-repo-review in the future.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--602.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->