### PR TITLE
Apply ruff/flake8-pyi rule PYI044

### DIFF
--- a/src/sp_repo_review/_version.pyi
+++ b/src/sp_repo_review/_version.pyi
@@ -1,4 +1,2 @@
-from __future__ import annotations
-
 version: str
 version_tuple: tuple[int, int, int] | tuple[int, int, int, str, str]


### PR DESCRIPTION
PYI044 `from __future__ import annotations` has no effect in stub files, since type checkers automatically treat stubs as having those semantics