### PR TITLE
fix: build commands is a valid alternative to build tools python

### DIFF
--- a/src/sp_repo_review/checks/readthedocs.py
+++ b/src/sp_repo_review/checks/readthedocs.py
@@ -96,6 +96,8 @@ class RTD103(ReadTheDocs):
         match readthedocs:
             case {"build": {"tools": {"python": object()}}}:
                 return True
+            case {"build": {"commands": object()}}:
+                return True
             case _:
                 return False
 

--- a/tests/test_readthedocs.py
+++ b/tests/test_readthedocs.py
@@ -52,6 +52,15 @@ def test_rtd103_true() -> None:
     assert compute_check("RTD103", readthedocs=readthedocs).result
 
 
+def test_rtd103_commands() -> None:
+    readthedocs = yaml.safe_load("""
+        build:
+          commands:
+            - one
+    """)
+    assert compute_check("RTD103", readthedocs=readthedocs).result
+
+
 def test_rtd103_false() -> None:
     readthedocs = yaml.safe_load("""
         build:


### PR DESCRIPTION
Noticed this with cibuildwheel.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--608.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->