### PR TITLE
fix: Python 3.13.4 broken on Windows

### DIFF
--- a/.github/workflows/reusable-cookie.yml
+++ b/.github/workflows/reusable-cookie.yml
@@ -38,7 +38,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-          check-latest: ${{ matrix.python-version == '3.13' }}
+          # Python 3.13.4 broken on Windows
+          check-latest: >-
+            ${{ matrix.python-version == '3.13' && runner.os == 'Windows' }}
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v6

--- a/docs/pages/guides/packaging_compiled.md
+++ b/docs/pages/guides/packaging_compiled.md
@@ -353,6 +353,11 @@ necessary to actually pin the oldest NumPy you supported (the
 
 If using pybind11, you don't need NumPy at build-time in the first place.
 
+{: .important }
+
+Python 3.13.4 is broken on Windows for compiling code - it always reports that
+it is free-threaded. 3.13.5 was rushed out to fix it.
+
 <!-- prettier-ignore-start -->
 
 [scikit-build-core]: https://scikit-build-core.readthedocs.io

--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -59,6 +59,13 @@ jobs:
         with:
           python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
           allow-prereleases: true
+          {%- if cookiecutter.__type == "compiled" %}
+          {%- raw %}
+          # Python 3.13.4 broken on Windows
+          check-latest: >-
+            ${{ matrix.python-version == '3.13' && runner.os == 'Windows' }}
+          {%- endraw %}
+          {%- endif %}
 
       - uses: astral-sh/setup-uv@v6
 


### PR DESCRIPTION
Follow for https://github.com/actions/setup-python/issues/1123, include template.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--613.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->