### PR TITLE
fix: allow poe as task manager

### DIFF
--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -146,6 +146,8 @@ class PY007(General):
                 return True
             case {"tox": object()}:
                 return True
+            case {"poe": object()}:
+                return True
             case {"pixi": {"tasks": {}}}:
                 return True
             case {"pixi": {"feature": feats}} if any(

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -156,6 +156,7 @@ def test_py007(tmp_path: Path, runnerfile: str):
         "[tool.tox]",
         "[tool.pixi.tasks]",
         "[tool.pixi.feature.thing.tasks]",
+        "[tool.poe]",
     ],
 )
 def test_py007_pyproject_sections(tmp_path: Path, section: str):


### PR DESCRIPTION
Fix #621.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--630.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->