### PR TITLE
fix: add a new md formatter

### DIFF
--- a/src/sp_repo_review/checks/precommit.py
+++ b/src/sp_repo_review/checks/precommit.py
@@ -128,13 +128,14 @@ class PC180(PreCommit):
     "Uses a markdown formatter"
 
     renamed = {
-        "https://github.com/pre-commit/mirrors-prettier": "https://github.com/rbubley/mirrors-prettier"
+        "https://github.com/pre-commit/mirrors-prettier": "https://github.com/rbubley/mirrors-prettier",
+        "https://github.com/executablebooks/mdformat": "https://github.com/hukkin/mdformat",
     }
 
     repos = {
         "https://github.com/rbubley/mirrors-prettier",
-        "https://github.com/executablebooks/mdformat",
         "https://github.com/hukkin/mdformat",
+        "https://github.com/rvben/rumdl-pre-commit",
     }
 
 

--- a/tests/test_precommit.py
+++ b/tests/test_precommit.py
@@ -130,10 +130,38 @@ def test_pc180():
     assert compute_check("PC180", precommit=precommit).result
 
 
-def test_pc180_alt_1():
+def test_pc180_rename():
     precommit = yaml.safe_load("""
         repos:
-          - repo: https://github.com/rbubley/mirrors-prettier
+          - repo: https://github.com/pre-commit/mirrors-prettier
+    """)
+    res = compute_check("PC180", precommit=precommit)
+    assert not res.result
+    assert "https://github.com/rbubley/mirrors-prettier" in res.err_msg
+
+
+def test_pc180_alt_2():
+    precommit = yaml.safe_load("""
+        repos:
+          - repo: https://github.com/hukkin/mdformat
+    """)
+    assert compute_check("PC180", precommit=precommit).result
+
+
+def test_pc180_rename_1():
+    precommit = yaml.safe_load("""
+        repos:
+          - repo: https://github.com/executablebooks/mdformat
+    """)
+    res = compute_check("PC180", precommit=precommit)
+    assert not res.result
+    assert "https://github.com/hukkin/mdformat" in res.err_msg
+
+
+def test_pc180_alt_3():
+    precommit = yaml.safe_load("""
+        repos:
+          - repo: https://github.com/rvben/rumdl-pre-commit
     """)
     assert compute_check("PC180", precommit=precommit).result
 


### PR DESCRIPTION
New Rust-based MD formatter from @rvben.

Also handling the rename of mdformat.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--631.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->