### PR TITLE
change the exclusion pattern for bots

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,7 +1,7 @@
 changelog:
   exclude:
     authors:
-      - dependabot
-      - github-actions
-      - pre-commit-ci
-      - scientific-python-pr-tokenbot
+      - dependabot[bot]
+      - github-actions[bot]
+      - pre-commit-ci[bot]
+      - scientific-python-pr-tokenbot[bot]

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -733,8 +733,8 @@ with code_fence("yaml"):
 changelog:
   exclude:
     authors:
-      - "dependabot[bot]"
-      - "pre-commit-ci[bot]"
+      - dependabot
+      - pre-commit-ci
 ```
 <!-- prettier-ignore-end -->
 <!-- [[[end]]] -->

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -733,8 +733,8 @@ with code_fence("yaml"):
 changelog:
   exclude:
     authors:
-      - dependabot
-      - pre-commit-ci
+      - "dependabot[bot]"
+      - "pre-commit-ci[bot]"
 ```
 <!-- prettier-ignore-end -->
 <!-- [[[end]]] -->

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -739,5 +739,8 @@ changelog:
 <!-- prettier-ignore-end -->
 <!-- [[[end]]] -->
 
-[gh-changelog]:
-  https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+<!-- prettier-ignore-start -->
+
+[gh-changelog]: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+<!-- prettier-ignore-end -->

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -733,8 +733,8 @@ with code_fence("yaml"):
 changelog:
   exclude:
     authors:
-      - dependabot
-      - pre-commit-ci
+      - dependabot[bot]
+      - pre-commit-ci[bot]
 ```
 <!-- prettier-ignore-end -->
 <!-- [[[end]]] -->

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -733,8 +733,8 @@ with code_fence("yaml"):
 changelog:
   exclude:
     authors:
-      - dependabot[bot]
-      - pre-commit-ci[bot]
+      - dependabot
+      - pre-commit-ci
 ```
 <!-- prettier-ignore-end -->
 <!-- [[[end]]] -->

--- a/{{cookiecutter.project_name}}/.github/release.yml
+++ b/{{cookiecutter.project_name}}/.github/release.yml
@@ -1,5 +1,5 @@
 changelog:
   exclude:
     authors:
-      - dependabot
-      - pre-commit-ci
+      - dependabot[bot]
+      - pre-commit-ci[bot]


### PR DESCRIPTION
It seems github changed the way the exclusion from auto-generated release notes works, such that this has to match what is displayed as author.

In other words, the only way I could get it to exclude the bots was to include the `[bot]` suffix for bots like `pre-commit-ci` and `dependabot`.

(not sure if I did something wrong, though)

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--636.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->