### PR TITLE
Change sdist build command to use 'uv'

### DIFF
--- a/docs/pages/guides/gha_wheels.md
+++ b/docs/pages/guides/gha_wheels.md
@@ -94,8 +94,9 @@ make_sdist:
         path: dist/*.tar.gz
 ```
 
-Instead of using `uv`, you can also run `pipx run build --sdist`, or install build via pip and use `python -m build --sdist`. You can
-also pin the version with `pipx run build==<version>`.
+Instead of using `uv`, you can also run `pipx run build --sdist`, or install
+build via pip and use `python -m build --sdist`. You can also pin the version
+with `pipx run build==<version>`.
 
 ## The core job (3 main OS's)
 


### PR DESCRIPTION
Since the guide was heavily using `uv` already, it's probably a good idea to also reference `uv build --sdist` as the primary option.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--641.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->