### PR TITLE
docs: mention uv high level to clarify statement

### DIFF
--- a/docs/_includes/pyproject.md
+++ b/docs/_includes/pyproject.md
@@ -117,8 +117,8 @@ because they are formally standardized (i.e. they will be more portable going
 forward) and they are more composable. In contrast with extras,
 dependency-groups are not available when installing your package via PyPI, but
 they are available for local installation (and can be installed separately from
-your package); the `dev` group is even installed, by default, when using `uv`.
-Here is an example:
+your package); the `dev` group is even installed, by default, when using `uv`'s
+high level commands like `uv run` and `uv sync`. Here is an example:
 
 ```toml
 [dependency-groups]


### PR DESCRIPTION
Someone got confused by this, thinking it would affect `uv pip install -e.`, so adding a little clarification.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--654.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->