### PR TITLE
chore: fix for pylint 4

### DIFF
--- a/src/sp_repo_review/checks/mypy.py
+++ b/src/sp_repo_review/checks/mypy.py
@@ -122,7 +122,7 @@ class MY104(MyPy):
         """
 
         match pyproject:
-            case {"tool": {"mypy": {"enable_error_code": list(codes)}}}:
+            case {"tool": {"mypy": {"enable_error_code": codes}}}:
                 return "ignore-without-code" in codes
             case _:
                 return False
@@ -147,7 +147,7 @@ class MY105(MyPy):
         """
 
         match pyproject:
-            case {"tool": {"mypy": {"enable_error_code": list(codes)}}}:
+            case {"tool": {"mypy": {"enable_error_code": codes}}}:
                 return "redundant-expr" in codes
             case _:
                 return False
@@ -172,7 +172,7 @@ class MY106(MyPy):
         """
 
         match pyproject:
-            case {"tool": {"mypy": {"enable_error_code": list(codes)}}}:
+            case {"tool": {"mypy": {"enable_error_code": codes}}}:
                 return "truthy-bool" in codes
             case _:
                 return False

--- a/src/sp_repo_review/checks/pyproject.py
+++ b/src/sp_repo_review/checks/pyproject.py
@@ -47,7 +47,7 @@ class PP003(PyProject):
         """
 
         match pyproject:
-            case {"build-system": {"requires": list(req)}}:
+            case {"build-system": {"requires": req}}:
                 return all(not r.startswith("wheel") for r in req)
             case _:
                 return False
@@ -73,9 +73,7 @@ class PP004(PyProject):
             case {
                 "tool": {
                     "poetry": {
-                        "dependencies": {
-                            "python": str(requires) | {"version": str(requires)}
-                        }
+                        "dependencies": {"python": requires} | {"version": requires}
                     }
                 }
             }:

--- a/src/sp_repo_review/checks/readthedocs.py
+++ b/src/sp_repo_review/checks/readthedocs.py
@@ -41,7 +41,7 @@ class RTD101(ReadTheDocs):
         """
 
         match readthedocs:
-            case {"version": int(x)} if x >= 2:
+            case {"version": x} if x >= 2:
                 return True
         return False
 

--- a/src/sp_repo_review/checks/ruff.py
+++ b/src/sp_repo_review/checks/ruff.py
@@ -124,9 +124,9 @@ class RF1xx(Ruff):
 
         match ruff:
             case (
-                {"lint": {"select": list(x)} | {"extend-select": list(x)}}
-                | {"select": list(x)}
-                | {"extend-select": list(x)}
+                {"lint": {"select": x} | {"extend-select": x}}
+                | {"select": x}
+                | {"extend-select": x}
             ):
                 return cls.code in x or "ALL" in x
             case _:


### PR DESCRIPTION
`list(x)` -> `list() as x`, though I think we can just match and assume the type is right, erroring if not, which is simpler (just `x`).


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--656.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->