### PR TITLE
fix: hide the setuptools family when not using it

### DIFF
--- a/src/sp_repo_review/checks/setupcfg.py
+++ b/src/sp_repo_review/checks/setupcfg.py
@@ -49,5 +49,9 @@ class SCFG001(SCFG):
         return ""
 
 
-def repo_review_checks() -> dict[str, SCFG]:
+def repo_review_checks(
+    list_all: bool = True, setupcfg: configparser.ConfigParser | None = None
+) -> dict[str, SCFG]:
+    if not list_all and setupcfg is None:
+        return {}
     return {p.__name__: p() for p in SCFG.__subclasses__()}


### PR DESCRIPTION
This doesn't need to show up if not using setuptools.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--657.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->