### PR TITLE
fix(pre-commit): only show errors

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,7 @@
   name: sp-repo-review
   description: Check for configuration best practices
   entry: repo-review .
+  args: [--show=err]
   language: python
   types_or: [text]
   pass_filenames: false


### PR DESCRIPTION
Only show errors in pre-commit (can overflow pre-commit.ci's truncation boundary otherwise). Fix #661.

