### PR TITLE
fix: include markdownlint-cli2

### DIFF
--- a/src/sp_repo_review/checks/precommit.py
+++ b/src/sp_repo_review/checks/precommit.py
@@ -138,6 +138,7 @@ class PC180(PreCommit):
         "https://github.com/rbubley/mirrors-prettier",
         "https://github.com/hukkin/mdformat",
         "https://github.com/rvben/rumdl-pre-commit",
+        "https://github.com/davidanson/markdownlint-cli2",
     }
 
 

--- a/tests/test_precommit.py
+++ b/tests/test_precommit.py
@@ -166,6 +166,14 @@ def test_pc180_alt_3():
     assert compute_check("PC180", precommit=precommit).result
 
 
+def test_pc180_alt_4():
+    precommit = yaml.safe_load("""
+        repos:
+          - repo: https://github.com/DavidAnson/markdownlint-cli2
+    """)
+    assert compute_check("PC180", precommit=precommit).result
+
+
 def test_pc191(ruff_check: str):
     precommit = yaml.safe_load(f"""
         repos:


### PR DESCRIPTION
Fix #521.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--672.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->