### PR TITLE
feat: check for dev dependency-group

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ for family, grp in itertools.groupby(collected.checks.items(), key=lambda x: x[1
 - [`PP003`](https://learn.scientific-python.org/development/guides/packaging-classic#PP003): Does not list wheel as a build-dep
 - [`PP004`](https://learn.scientific-python.org/development/guides/packaging-simple#PP004): Does not upper cap Python requires
 - [`PP005`](https://learn.scientific-python.org/development/guides/packaging-simple#PP005): Using SPDX project.license should not use deprecated trove classifiers
+- [`PP006`](https://learn.scientific-python.org/development/guides/packaging-simple#PP006): The dev dependency group should be defined
 - [`PP301`](https://learn.scientific-python.org/development/guides/pytest#PP301): Has pytest in pyproject
 - [`PP302`](https://learn.scientific-python.org/development/guides/pytest#PP302): Sets a minimum pytest to at least 6
 - [`PP303`](https://learn.scientific-python.org/development/guides/pytest#PP303): Sets the test paths

--- a/docs/_includes/pyproject.md
+++ b/docs/_includes/pyproject.md
@@ -118,7 +118,8 @@ forward) and they are more composable. In contrast with extras,
 dependency-groups are not available when installing your package via PyPI, but
 they are available for local installation (and can be installed separately from
 your package); the `dev` group is even installed, by default, when using `uv`'s
-high level commands like `uv run` and `uv sync`. Here is an example:
+high level commands like `uv run` and `uv sync`. {% rr PP0086 %} Here is an
+example:
 
 ```toml
 [dependency-groups]

--- a/src/sp_repo_review/checks/pyproject.py
+++ b/src/sp_repo_review/checks/pyproject.py
@@ -120,6 +120,32 @@ class PP005(PyProject):
                 return None
 
 
+class PP006(PyProject):
+    "The dev dependency group should be defined"
+
+    requires = {"PY001"}
+    url = mk_url("packaging-simple")
+
+    @staticmethod
+    def check(pyproject: dict[str, Any]) -> bool:
+        """
+        The `dev` dependency group should be defined so tools like uv will work.
+        These are better than the old `extras` system for tests, docs, and other
+        dependencies that are not needed for PyPI installs.
+
+        ```toml
+        [dependency-groups]
+        dev = [ {{ include-group = "test" }} ]
+        test = [ "pytest" ]
+        ```
+        """
+        match pyproject:
+            case {"dependency-groups": {"dev": list()}}:
+                return True
+            case _:
+                return False
+
+
 class PP301(PyProject):
     "Has pytest in pyproject"
 

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -182,6 +182,25 @@ def test_PP005_both():
     assert not compute_check("PP005", pyproject=toml).result
 
 
+def test_PP006_present():
+    toml = toml_loads("""
+        [dependency-groups]
+        dev = [ { include-group = "test" } ]
+        test = [ "pytest" ]
+        """)
+
+    assert compute_check("PP006", pyproject=toml).result
+
+
+def test_PP006_missing():
+    toml = toml_loads("""
+        [dependency-groups]
+        test = [ "pytest" ]
+        """)
+
+    assert not compute_check("PP006", pyproject=toml).result
+
+
 def test_PP302_okay_intstr():
     toml = toml_loads("""
         [tool.pytest.ini_options]


### PR DESCRIPTION
Now that uv has deprecated the tool.uv.dev-dependency thing, I think it's time to list this. I _think_ you can export extras with `package_name[test]`, but not sure, I've kept them separate mostly.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--673.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->