### PR TITLE
fix: use log_level instead of log_cli_level

### DIFF
--- a/docs/pages/guides/pytest.md
+++ b/docs/pages/guides/pytest.md
@@ -76,7 +76,7 @@ minversion = "6.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = ["error"]
-log_cli_level = "info"
+log_level = "INFO"
 testpaths = [
   "tests",
 ]
@@ -95,7 +95,7 @@ config. {% rr PP305 %} `xfail_strict` will change the default for `xfail` to
 fail the tests if it doesn't fail - you can still override locally in a specific
 xfail for a flaky failure. {% rr PP309 %} `filter_warnings` will cause all
 warnings to be errors (you can add allowed warnings here too, see below).
-{% rr PP304 %} `log_cli_level` will report `INFO` and above log messages on a
+{% rr PP304 %} `log_level` will report `INFO` and above log messages on a
 failure. {% rr PP303 %} Finally, `testpaths` will limit `pytest` to just looking
 in the folders given - useful if it tries to pick up things that are not tests
 from other directories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ start-after = "<!-- sp-repo-review -->"
 minversion = "7.0"
 addopts = ["-ra", "--strict-markers", "--strict-config"]
 xfail_strict = true
-log_cli_level = "INFO"
+log_level = "INFO"
 filterwarnings = [
   'error',
 ]

--- a/src/sp_repo_review/checks/pyproject.py
+++ b/src/sp_repo_review/checks/pyproject.py
@@ -220,16 +220,16 @@ class PP304(PyProject):
     @staticmethod
     def check(pyproject: dict[str, Any]) -> bool:
         """
-        `log_cli_level` should be set. This will allow logs to be displayed on
+        `log_level` should be set. This will allow logs to be displayed on
         failures.
 
         ```toml
         [tool.pytest.ini_options]
-        log_cli_level = "INFO"
+        log_level = "INFO"
         ```
         """
         options = pyproject["tool"]["pytest"]["ini_options"]
-        return "log_cli_level" in options
+        return "log_cli_level" in options or "log_level" in options
 
 
 class PP305(PyProject):

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -248,7 +248,7 @@ xfail_strict = true
 filterwarnings = [
   "error",
 ]
-log_cli_level = "INFO"
+log_level = "INFO"
 testpaths = [
   "tests",
 ]


### PR DESCRIPTION
Close #679. Not sure why we have `log_cli_level`, though they happen do to pretty much exactly the same thing in a configuration file. We could eventually make the check error on `log_cli_level`, pointing out the alternative, but let's allow both for a bit.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--680.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->