### PR TITLE
fix: update pytest configuration tabs in documentation

### DIFF
--- a/docs/pages/guides/pytest.md
+++ b/docs/pages/guides/pytest.md
@@ -392,3 +392,5 @@ redirects to the standard library [unittest.mock][].
 [pytest]: https://docs.pytest.org
 [pytest-mock]: https://pypi.org/project/pytest-mock/
 [unittest.mock]: https://docs.python.org/3/library/unittest.mock.html
+
+<script src="{% link assets/js/tabs.js %}"></script>


### PR DESCRIPTION
Issues switching

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--684.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->