### PR TITLE
fix: if show-fixes is set in config, count that

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ messages_control.disable = [
   "invalid-name",
   "redefined-outer-name",
   "no-member",  # better handled by mypy, etc.
+  "arguments-differ",  # better handled by mypy, etc.
 ]
 
 

--- a/src/sp_repo_review/checks/precommit.py
+++ b/src/sp_repo_review/checks/precommit.py
@@ -149,7 +149,7 @@ class PC191(PreCommit):
     repos = {"https://github.com/astral-sh/ruff-pre-commit"}
 
     @classmethod
-    def check(cls, precommit: dict[str, Any]) -> bool | None:
+    def check(cls, precommit: dict[str, Any], ruff: dict[str, Any]) -> bool | None:  # type: ignore[override]
         """
         If `--fix` is present, `--show-fixes` must be too.
         """
@@ -161,7 +161,7 @@ class PC191(PreCommit):
                         and "args" in hook
                         and "--fix" in hook["args"]
                     ):
-                        return "--show-fixes" in hook["args"]
+                        return "--show-fixes" in hook["args"] or "show-fixes" in ruff
                 return None
         return False
 

--- a/tests/test_precommit.py
+++ b/tests/test_precommit.py
@@ -182,7 +182,18 @@ def test_pc191(ruff_check: str):
               - id: {ruff_check}
                 args: ["--fix", "--show-fixes"]
     """)
-    assert compute_check("PC191", precommit=precommit).result
+    assert compute_check("PC191", precommit=precommit, ruff={}).result
+
+
+def test_pc191_ruffconfig(ruff_check: str):
+    precommit = yaml.safe_load(f"""
+        repos:
+          - repo: https://github.com/astral-sh/ruff-pre-commit
+            hooks:
+              - id: {ruff_check}
+                args: ["--fix"]
+    """)
+    assert compute_check("PC191", precommit=precommit, ruff={"show-fixes": True}).result
 
 
 def test_pc191_no_show_fixes(ruff_check: str):
@@ -193,7 +204,7 @@ def test_pc191_no_show_fixes(ruff_check: str):
               - id: {ruff_check}
                 args: ["--fix"]
     """)
-    res = compute_check("PC191", precommit=precommit)
+    res = compute_check("PC191", precommit=precommit, ruff={})
     assert not res.result
     assert "--show-fixes" in res.err_msg
 


### PR DESCRIPTION
This is also allowed in config.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--686.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->