### PR TITLE
fix: skip readthedocs if no readthedocs file present

### DIFF
--- a/src/sp_repo_review/checks/readthedocs.py
+++ b/src/sp_repo_review/checks/readthedocs.py
@@ -148,7 +148,9 @@ def readthedocs(root: Traversable) -> dict[str, Any]:
     return {}
 
 
-def repo_review_checks(list_all: bool = True, readthedocs: dict[str, Any] | None = None) -> dict[str, ReadTheDocs]:
+def repo_review_checks(
+    list_all: bool = True, readthedocs: dict[str, Any] | None = None
+) -> dict[str, ReadTheDocs]:
     if not list_all and not readthedocs:
         return {}
     return {p.__name__: p() for p in ReadTheDocs.__subclasses__()}


### PR DESCRIPTION
I think it's been long enough that most projects targeting readthedocs will have a readthedocs file now, so let's skip this family if it's missing, just like setupcfg.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--693.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->