### PR TITLE
ci: only compare generation on Linux (faster)

### DIFF
--- a/.github/workflows/reusable-cookie.yml
+++ b/.github/workflows/reusable-cookie.yml
@@ -91,9 +91,11 @@ jobs:
         run: nox -s 'tests(mesonpy, novcs, sphinx)'
 
       - name: Compare copier template generation
+        if: runner.os == 'Linux' # No need to check this on each (slow on Windows)
         run: nox -s compare_copier
 
       - name: Compare cruft template generation
+        if: runner.os == 'Linux' # No need to check this on each (slow on Windows)
         run: nox -s compare_cruft
 
   nox:


### PR DESCRIPTION
This should speed up the overall CI time.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--699.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->