### PR TITLE
fix: drop old log level from check

### DIFF
--- a/src/sp_repo_review/checks/pyproject.py
+++ b/src/sp_repo_review/checks/pyproject.py
@@ -264,7 +264,7 @@ class PP304(PyProject):
         ```
         """
         _, options = pytest
-        return "log_cli_level" in options or "log_level" in options
+        return "log_level" in options
 
 
 class PP305(PyProject):

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -278,11 +278,11 @@ def test_PP304_okay():
     assert compute_check("PP304", pytest=(PytestFile.LEGACY_PYPROJECT, toml)).result
 
 
-def test_PP304_alt_okay():
+def test_PP304_alt_not_okay():
     toml = toml_loads("""
         log_cli_level = "INFO"
         """)
-    assert compute_check("PP304", pytest=(PytestFile.LEGACY_PYPROJECT, toml)).result
+    assert not compute_check("PP304", pytest=(PytestFile.LEGACY_PYPROJECT, toml)).result
 
 
 def test_PP304_missing():


### PR DESCRIPTION
We had a short period where both were accepted, now I think it's time to help projects that used the old recommendation to move (or skip/ignore the check, of course).


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--701.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->