### PR TITLE
fix: hide pre-commit checks if lefthook is used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,10 @@ messages_control.disable = [
 ]
 
 
+[tool.ruff]
+show-fixes = true
+extend-exclude = ["\\{\\{cookiecutter.project_name\\}\\}"]
+
 [tool.ruff.lint]
 extend-select = [
   "ARG",    # flake8-unused-arguments

--- a/src/sp_repo_review/checks/precommit.py
+++ b/src/sp_repo_review/checks/precommit.py
@@ -245,5 +245,14 @@ class PC903(PreCommit):
         return "autoupdate_schedule" in precommit.get("ci", {})
 
 
-def repo_review_checks() -> dict[str, PreCommit]:
+def repo_review_checks(
+    list_all: bool = True,
+    root: Traversable | None = None,
+) -> dict[str, PreCommit]:
+    if root and not list_all:
+        precommit_path = root.joinpath(".pre-commit-config.yaml")
+        lefthook_path = root.joinpath("lefthook.yml")
+        if not precommit_path.is_file() and lefthook_path.is_file():
+            return {}
+
     return {p.__name__: p() for p in PreCommit.__subclasses__()}


### PR DESCRIPTION
Fix #577. The pre-commit checks will be disabled if lefthook is present and pre-commit is not.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--702.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->