### PR TITLE
Correct .pre-commit-config.yaml filename in version bump

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -425,8 +425,8 @@ def pc_bump(session: nox.Session) -> None:
     versions = {}
     pages = [
         Path("docs/pages/guides/style.md"),
-        Path("{{cookiecutter.project_name}}/.prek-config.yaml"),
-        Path(".prek-config.yaml"),
+        Path("{{cookiecutter.project_name}}/.pre-commit-config.yaml"),
+        Path(".pre-commit-config.yaml"),
     ]
 
     for page in pages:


### PR DESCRIPTION
I guess the transition to `prek` in #696 was a little too aggressive :smile: 

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--707.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->