### PR TITLE
fix: use modern hatch test and dependency-groups

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -272,7 +272,7 @@ def native(session: nox.Session, backend: str, vcs: bool, docs: Docs) -> None:
     session.chdir(cookie)
 
     if backend == "hatch":
-        session.run(backend, "run", "test")
+        session.run(backend, "test")
     elif backend == "poetry":
         session.run(backend, "sync", env={"VIRTUAL_ENV": None})
         session.run(backend, "run", "pytest", env={"VIRTUAL_ENV": None})

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -178,10 +178,11 @@ build.hooks.vcs.version-file = "src/{{ cookiecutter.__project_slug }}/_version.p
 {%- endif %}
 
 [tool.hatch.envs.default]
-# duplicate for now since hatch doesn't support groups yet
-dependencies = []
-scripts.test = "pytest {args}"
+dependency-groups = ["dev"]
 
+[tool.hatch.envs.hatch-test]
+dependency-groups = ["test"]
+env-vars.PYTHONWARNDEFAULTENCODING = "1"
 
 {%- elif cookiecutter.backend == "pdm" %}
 {%- if cookiecutter.vcs %}


### PR DESCRIPTION
Hatch now supports this.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--716.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->