### PR TITLE
fix: follow noxfile recommendation NOX201, NOX202, NOX203

### DIFF
--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -1,3 +1,11 @@
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# dependencies = ["nox>=2025.2.9"]
+# ///
+
+"""Nox runner."""
+
 from __future__ import annotations
 
 {% if cookiecutter.docs == 'sphinx' -%}
@@ -133,3 +141,7 @@ def build(session: nox.Session) -> None:
 
     session.install("build")
     session.run("python", "-m", "build")
+
+
+if __name__ == "__main__":
+    nox.main()


### PR DESCRIPTION
The `noxfile.py` of a project created with `cookie` is not following the recommendation NOX201, NOX202, NOX203.

This PR fixes this.

```
├── NOX201 Set a script block with dependencies in your noxfile ❌
│   You should have a script block with nox in it, for example:                                                                                                                               
│   
│                                                                                                                                                                                             
│    # /// script                                                                                                                                                                             
│    dependencies = ["nox"]                                                                                                                                                                   
│    # ///                                                                                                                                                                                    
│                                                                                                                                                                                             
├── NOX202 Has a shebang line ❌
│   You should have a shebang line at the top of your noxfile.py, for example:                                                                                                                
│   
│                                                                                                                                                                                             
│    #!/usr/bin/env -S uv run --script                                                                                                                                                        
│                                                                                                                                                                                             
└── NOX203 Provide a main block to run nox ❌
    You should have a main block at the bottom of your noxfile.py, for example:                                                                                                               
    
                                                                                                                                                                                              
     if __name__ == "__main__":                                                                                                                                                               
         nox.main()  
```

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--720.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->