### PR TITLE
chore: use pytest 9+, default to that

### DIFF
--- a/docs/_includes/pyproject.md
+++ b/docs/_includes/pyproject.md
@@ -149,8 +149,8 @@ with code_fence("toml"):
 ```toml
 [dependency-groups]
 test = [
-  "pytest >=6",
-  "pytest-cov >=3",
+  "pytest >=9",
+  "pytest-cov >=7",
 ]
 dev = [
   { include-group = "test" },

--- a/docs/pages/guides/pytest.md
+++ b/docs/pages/guides/pytest.md
@@ -71,13 +71,13 @@ pytest supports configuration in `pytest.ini`, `setup.cfg`, or, since version 6,
 always require 6+ (or 9+) and use `pyproject.toml` or the pytest TOML ones. This
 is an example configuration:
 
-{% tabs %} {% tab conf-classic Pytest 6+ %}
+{% tabs %} {% tab conf-modern Pytest 9+ %}
 
 ```toml
-[tool.pytest.ini_options]
-minversion = "6.0"
-addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
-xfail_strict = true
+[tool.pytest]
+minversion = "9.0"
+addopts = ["-ra", "--showlocals"]
+strict = true
 filterwarnings = ["error"]
 log_level = "INFO"
 testpaths = [
@@ -85,13 +85,13 @@ testpaths = [
 ]
 ```
 
-{% endtab %} {% tab conf-modern Pytest 9+ %}
+{% endtab %} {% tab conf-classic Pytest 6+ %}
 
 ```toml
-[tool.pytest]
-minversion = "9.0"
-addopts = ["-ra", "--showlocals"]
-strict = true
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
+xfail_strict = true
 filterwarnings = ["error"]
 log_level = "INFO"
 testpaths = [

--- a/docs/pages/principles/testing.md
+++ b/docs/pages/principles/testing.md
@@ -153,7 +153,7 @@ conceptually part of a larger suite, and skip them when needed.
 First, define a new marker in `pyproject.toml`:
 
 ```toml
-[tool.pytest.ini_options]
+[tool.pytest]
 markers = [
     "unit: marks unit tests",
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dev = [
   "validate-pyproject-schema-store[all]",
 ]
 test = [
-  "pytest >=7",
+  "pytest >=9",
   "repo-review >=0.10.6",
 ]
 cog = [
@@ -110,10 +110,10 @@ content-type = "text/markdown"
 path = "README.md"
 start-after = "<!-- sp-repo-review -->"
 
-[tool.pytest.ini_options]
-minversion = "7.0"
-addopts = ["-ra", "--strict-markers", "--strict-config"]
-xfail_strict = true
+[tool.pytest]
+minversion = "9.0"
+addopts = ["-ra"]
+strict = true
 log_level = "INFO"
 filterwarnings = [
   'error',

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -119,8 +119,8 @@ Changelog = "{{ cookiecutter.url }}/releases"
 
 [dependency-groups]
 test = [
-  "pytest >=6",
-  "pytest-cov >=3",
+  "pytest >=9",
+  "pytest-cov >=7",
 ]
 dev = [
   { include-group = "test" },
@@ -218,8 +218,8 @@ substitution.files = ["src/{{ cookiecutter.__project_slug }}/__init__.py"]
 {%- endif %}
 
 [tool.poetry.group.test.dependencies]
-pytest = ">= 6"
-pytest-cov = ">= 3"
+pytest = ">= 9"
+pytest-cov = ">= 7"
 {%- endif %}
 
 
@@ -241,10 +241,10 @@ test-extras = ["test"]
 {%- endif %}
 
 
-[tool.pytest.ini_options]
-minversion = "6.0"
-addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
-xfail_strict = true
+[tool.pytest]
+minversion = "9.0"
+addopts = ["-ra", "--showlocals"]
+strict = true
 filterwarnings = [
   "error",
 ]


### PR DESCRIPTION
Let's use pytest 9+ and put that in the template, no need for legacy support in a template.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--725.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->