### PR TITLE
fix: Add missing leading `#` to sp-repo-review's NOX201 example

### DIFF
--- a/src/sp_repo_review/checks/noxfile.py
+++ b/src/sp_repo_review/checks/noxfile.py
@@ -179,7 +179,7 @@ class NOX201(Nox):
 
         ```toml
         # /// script
-        dependencies = ["nox"]
+        # dependencies = ["nox"]
         # ///
         ```
         """


### PR DESCRIPTION
In order to make it a valid PEP 723 block.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--731.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->