### PR TITLE
ENH: allow tox.toml in rule `PY007`

### DIFF
--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -138,7 +138,7 @@ class PY007(General):
         `tool.hatch.envs`/`tool.spin`/`tool.tox` in `pyproject.toml` to encourage new
         contributors.
         """
-        if any(root.joinpath(fn).is_file for fn in PY007_VALID_RUNNER_CONFS):
+        if any(root.joinpath(fn).is_file() for fn in PY007_VALID_RUNNER_CONFS):
             return True
         match pyproject.get("tool", {}):
             case {"hatch": {"envs": object()}}:

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -141,7 +141,7 @@ def test_py006_missing(tmp_path: Path):
     assert not compute_check("PY006", root=simple).result
 
 
-@pytest.mark.parametrize("runnerfile", PY007_VALID_RUNNER_CONFS)
+@pytest.mark.parametrize("runnerfile", sorted(PY007_VALID_RUNNER_CONFS))
 def test_py007(tmp_path: Path, runnerfile: str):
     simple = tmp_path / "simple"
     simple.mkdir()


### PR DESCRIPTION
I also needed to refactor `PY007.check` to survive linting (adding a new conditional in the existing style would get it flagged as too complex), so I also seized the opportunity to tighten the associated test so it would be locked in-sync.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--739.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->