### PR TITLE
docs: fix malformed GHA images table

### DIFF
--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -138,13 +138,15 @@ There are a variety of
 [images to pick from](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners),
 such as:
 
-| Image name | Description | |==================|=============| |
-`ubuntu-latest` | Standard Linux runner (specific versions available) | |
-`windows-latest` | Standard Windows runner (specific versions available) | |
-`macos-latest` | Standard MacOS runner (specific versions available) | |
-`ubuntu-24.04-arm` | Linux ARM runner (no `latest` tag) | | `windows-11-arm` |
-Windows ARM runner (no specific versions) | | `macos-15-intel` | MacOS Intel
-runner (final version) | | `ubuntu-slim` | Fast startup single-core container |
+| Image name         | Description                                           |
+| ------------------ | ----------------------------------------------------- |
+| `ubuntu-latest`    | Standard Linux runner (specific versions available)   |
+| `windows-latest`   | Standard Windows runner (specific versions available) |
+| `macos-latest`     | Standard MacOS runner (specific versions available)   |
+| `ubuntu-24.04-arm` | Linux ARM runner (no `latest` tag)                    |
+| `windows-11-arm`   | Windows ARM runner (no specific versions)             |
+| `macos-15-intel`   | MacOS Intel runner (final version)                    |
+| `ubuntu-slim`      | Fast startup single-core container                    |
 
 Note that while versioned images are available, like `ubuntu-24.04`, these are
 all rolling images; selecting a specific image will not make your CI completely

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -142,10 +142,10 @@ such as:
 | ------------------ | ----------------------------------------------------- |
 | `ubuntu-latest`    | Standard Linux runner (specific versions available)   |
 | `windows-latest`   | Standard Windows runner (specific versions available) |
-| `macos-latest`     | Standard MacOS runner (specific versions available)   |
+| `macos-latest`     | Standard macOS runner (specific versions available)   |
 | `ubuntu-24.04-arm` | Linux ARM runner (no `latest` tag)                    |
 | `windows-11-arm`   | Windows ARM runner (no specific versions)             |
-| `macos-15-intel`   | MacOS Intel runner (final version)                    |
+| `macos-15-intel`   | macOS Intel runner (final version)                    |
 | `ubuntu-slim`      | Fast startup single-core container                    |
 
 Note that while versioned images are available, like `ubuntu-24.04`, these are


### PR DESCRIPTION
As title. It looks like it may have been a remnant of a linter doing something unintended:

<img width="1472" height="1470" alt="learn scientific-python org_development_guides_gha-basic_" src="https://github.com/user-attachments/assets/6640d78e-37e9-48bb-9455-d3a7821696be" />

The above is what I can currently see on https://learn.scientific-python.org/development/guides/gha-basic/#unit-tests.

Thank you!


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--780.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->