### PR TITLE
Remove reference to gautamkrishnar/keepalive-workflow that violates GitHub ToS

### DIFF
--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -297,9 +297,6 @@ And many other useful ones:
   afterwards.
 - [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv): Set up `uv`.
   Ultra-fast alternative to classic Python packaging solutions.
-- [gautamkrishnar/keepalive-workflow](https://github.com/gautamkrishnar/keepalive-workflow):
-  Keep GitHub actions alive for more than 60 days. Not usually needed if you've
-  set up the other suggestions here, like dependabot and pre-commit.
 - [sigstore/gh-action-sigstore-python](https://github.com/sigstore/gh-action-sigstore-python):
   Signing files in GitHub Actions with sigstore.
 


### PR DESCRIPTION
Removes a reference to https://github.com/gautamkrishnar/keepalive-workflow, because the repository has been disabled as a result of violating the GitHub ToS. See the conversation at https://github.com/nanos/FediFetcher/issues/198, specifically the attachment at https://github.com/nanos/FediFetcher/issues/198#issuecomment-2821948375, which I believe was sent to the author after a support request.

Surprisingly, it still shows up on the marketplace at https://github.com/marketplace/actions/keepalive-workflow 

There seem to be a few workarounds that are not very popular and thus GitHub has not quite managed to run into yet:
- https://github.com/efrecon/gh-action-keepalive
- https://github.com/marketplace/actions/keep-your-github-actions-alive-automatically

However, I'd suggest not including anything here, as those who want to find such a solution for their repository might just be able to do so through a search engine hit, like I was able to above. Usage of such actions carries a risk of such altercations by GitHub, which I don't think we should invite for our users by offering any advice – they are free to do this on their own accord.





<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--781.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->