### PR TITLE
chore: use native readthedocs uv integration

### DIFF
--- a/docs/pages/guides/docs.md
+++ b/docs/pages/guides/docs.md
@@ -499,17 +499,22 @@ with code_fence("yaml"):
 
 version: 2
 
+
+
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
-  commands:
-    - asdf plugin add uv
-    - asdf install uv latest
-    - asdf global uv latest
-    - uv sync --group docs
-    - uv run python -m sphinx -T -b html -d docs/_build/doctrees -D language=en
-      docs $READTHEDOCS_OUTPUT/html
+    python: "3.14"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: uv
+      command: sync
+      groups:
+        - docs
 ```
 <!-- prettier-ignore-end -->
 <!-- [[[end]]] -->
@@ -527,10 +532,13 @@ with code_fence("yaml"):
 
 version: 2
 
+
+
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.14"
+
   commands:
     - asdf plugin add uv
     - asdf install uv latest

--- a/docs/pages/guides/docs.md
+++ b/docs/pages/guides/docs.md
@@ -499,8 +499,6 @@ with code_fence("yaml"):
 
 version: 2
 
-
-
 build:
   os: ubuntu-24.04
   tools:
@@ -531,8 +529,6 @@ with code_fence("yaml"):
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 version: 2
-
-
 
 build:
   os: ubuntu-24.04

--- a/{{cookiecutter.project_name}}/.readthedocs.yaml
+++ b/{{cookiecutter.project_name}}/.readthedocs.yaml
@@ -3,22 +3,38 @@
 
 version: 2
 
+
+
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.14"
+
+{%- if cookiecutter.docs == 'sphinx' %}
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: uv
+      command: sync
+      groups:
+        - docs
+
+{%- else %}
+
   commands:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
     - uv sync --group docs 
-    {%- if cookiecutter.docs == 'sphinx' %}
-    - uv run python -m sphinx -T -b html -d docs/_build/doctrees -D language=en
-      docs $READTHEDOCS_OUTPUT/html
-    {%- elif cookiecutter.docs == 'mkdocs' %}
+    {%- if cookiecutter.docs == 'mkdocs' %}
     - uv run mkdocs build --site-dir $READTHEDOCS_OUTPUT/html
     {%- elif cookiecutter.docs == 'zensical' %}
     - uv run zensical build
     - mkdir -p $READTHEDOCS_OUTPUT/html/
     - cp --recursive site/* $READTHEDOCS_OUTPUT/html/
     {%- endif %}
+
+{%- endif %}

--- a/{{cookiecutter.project_name}}/.readthedocs.yaml
+++ b/{{cookiecutter.project_name}}/.readthedocs.yaml
@@ -3,8 +3,6 @@
 
 version: 2
 
-
-
 build:
   os: ubuntu-24.04
   tools:


### PR DESCRIPTION
Use native uv integration.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--783.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->