### PR TITLE
feat: allow pyrefly instead of mypy

### DIFF
--- a/src/sp_repo_review/checks/precommit.py
+++ b/src/sp_repo_review/checks/precommit.py
@@ -115,7 +115,10 @@ class PC190(PreCommit):
 class PC140(PreCommit):
     "Uses a type checker"
 
-    repos = {"https://github.com/pre-commit/mirrors-mypy"}
+    repos = {
+        "https://github.com/pre-commit/mirrors-mypy",
+        "https://github.com/facebook/pyrefly-pre-commit",
+    }
 
 
 class PC160(PreCommit):

--- a/tests/test_precommit.py
+++ b/tests/test_precommit.py
@@ -134,6 +134,14 @@ def test_pc140():
     assert compute_check("PC140", precommit=precommit).result
 
 
+def test_pc140_pyrefly():
+    precommit = yaml.safe_load("""
+        repos:
+          - repo: https://github.com/facebook/pyrefly-pre-commit
+    """)
+    assert compute_check("PC140", precommit=precommit).result
+
+
 def test_pc160_codespell():
     precommit = yaml.safe_load("""
         repos:


### PR DESCRIPTION
Minimum for #788.

I'd also like to adapt the mypy checks, and add tabbed examples. But we kind of name everything "mypy", and I've not used pyrefly yet. I'll try it out somewhere. glm-5.1 wrote a variaion of the mypy checks for pyrefly, I might paste them here for reference, though it's probalby not the right way to go - I think I'd rather the mypy checks to also understand other type checkers.

Assisted-by: OpenCode:glm-5.1


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--789.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->