### PR TITLE
docs: add prek tabs to GitHub Actions docs

### DIFF
--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -55,11 +55,24 @@ run on PRs targeting those branches only).
 
 ## Pre-commit
 
-If you use [pre-commit](https://pre-commit.com) (and you should), and you don't
-want to / can't use [pre-commit.ci](https://pre-commit.ci) yet, then this is a
-job that will check pre-commit for you:
+{% rr PY006 %} If you use [pre-commit][] (or [prek][]) in CI, you can run it
+directly in GitHub Actions. Prek is a faster Rust rewrite of pre-commit that
+supports most real world usage.
 
-{% raw %}
+{% tabs runner %} {% tab prek Prek %}
+
+```yaml
+lint:
+  name: Lint
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v6
+    - uses: j178/prek-action@v2
+```
+
+{% endtab %} {% tab pre-commit Pre-commit %}
+
+Pre-commit can run using the official action:
 
 ```yaml
 lint:
@@ -73,7 +86,7 @@ lint:
     - uses: pre-commit/action@v3.0.1
 ```
 
-{% endraw %}
+{% endtab %} {% endtabs %}
 
 If you do use [pre-commit.ci](https://pre-commit.ci), but you need this job to
 run a manual check, like check-manifest, then you can keep it but just use
@@ -757,6 +770,10 @@ changelog:
 
 <!-- prettier-ignore-start -->
 
-[gh-changelog]: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+[pre-commit]: https://pre-commit.com
+[prek]: https://github.com/j178/prek
+[gh-changelog]: https://docs.github.com/en/repositories/releasing-projects
 
 <!-- prettier-ignore-end -->
+
+<script src="{% link assets/js/tabs.js %}"></script>

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -55,9 +55,9 @@ run on PRs targeting those branches only).
 
 ## Pre-commit
 
-If you use [pre-commit][] (or [prek][]) in CI, you can run it
-directly in GitHub Actions. Prek is a faster Rust rewrite of pre-commit that
-supports most real world usage.
+If you use [pre-commit][] (or [prek][]) in CI, you can run it directly in GitHub
+Actions. Prek is a faster Rust rewrite of pre-commit that supports most real
+world usage.
 
 {% tabs runner %} {% tab prek Prek %}
 

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -57,7 +57,7 @@ run on PRs targeting those branches only).
 
 If you use [prek][] or [pre-commit][] in CI, you can run it directly in GitHub
 Actions. Prek is a faster Rust rewrite of pre-commit that supports most real
-world usage and supports the same configuraiton and hooks.
+world usage and supports the same configuration and hooks.
 
 {% tabs runner %} {% tab prek Prek %}
 

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -53,13 +53,15 @@ you use a develop branch, you probably will want to include that. You can also
 specify specific branches for pull requests instead of running on all PRs (will
 run on PRs targeting those branches only).
 
-## Pre-commit
+## Prek / Pre-commit
 
-If you use [pre-commit][] (or [prek][]) in CI, you can run it directly in GitHub
+If you use [prek][] or [pre-commit][] in CI, you can run it directly in GitHub
 Actions. Prek is a faster Rust rewrite of pre-commit that supports most real
-world usage.
+world usage and supports the same configuraiton and hooks.
 
 {% tabs runner %} {% tab prek Prek %}
+
+Prek can run using the official action:
 
 ```yaml
 lint:

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -55,7 +55,7 @@ run on PRs targeting those branches only).
 
 ## Pre-commit
 
-{% rr PY006 %} If you use [pre-commit][] (or [prek][]) in CI, you can run it
+If you use [pre-commit][] (or [prek][]) in CI, you can run it
 directly in GitHub Actions. Prek is a faster Rust rewrite of pre-commit that
 supports most real world usage.
 

--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -17,7 +17,15 @@ custom_title: Style and static checks
 to check code style. The original, `pre-commit`, has support for more languages,
 but `prek` is a faster Rust rewrite that supports most real world usage.
 
-{% tabs runner %} {% tab pre-commit Pre-commit %}
+{% tabs runner %} {% tab prek Prek %}
+
+Prek can be installed through `brew` (macOS) or `pipx/uv` (anywhere). There are
+two modes to use it locally; you can check manually with `prek run` (changes
+only) or `prek run -a` (all). You can omit the `run`, as well; such as
+`prek -a`. You can also run `prek install` to add checks as a git pre-commit
+hook.
+
+{% endtab %} {% tab pre-commit Pre-commit %}
 
 Pre-commit can be installed through `brew` (macOS) or `pipx/uv` (anywhere).
 There are two modes to use it locally; you can check manually with
@@ -27,14 +35,6 @@ gets its name).
 
 Pre-commit's setup is much slower than prek, but you can install `pre-commit-uv`
 with pre-commit to speed up the setup time quite a bit.
-
-{% endtab %} {% tab prek Prek %}
-
-Prek can be installed through `brew` (macOS) or `pipx/uv` (anywhere). There are
-two modes to use it locally; you can check manually with `prek run` (hanges
-only) or `prek run -a` (all). You can omit the `run`, as well; such as
-`prek -a`. You can also run `prek install` to add checks as a git pre-commit
-hook.
 
 {% endtab %} {% endtabs %}
 

--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -47,8 +47,6 @@ a custom pre-commit hook before; it's quite elegant and does not add or commit
 the changes, it just makes the changes and allows you to check and add them. You
 can always override the hook with `-n`.
 
-[pre-commit]: https://pre-commit.com
-
 {% rr PC100 %} Here is a minimal `.pre-commit-config.yaml` file with some handy
 options:
 
@@ -1047,6 +1045,8 @@ You also might like the following hook, which cleans Jupyter outputs:
 [schemastore]: https://schemastore.org
 [typos]: https://github.com/crate-ci/typos
 [typos-ref]: https://github.com/crate-ci/typos/blob/master/docs/reference.md
+[pre-commit]: https://pre-commit.com
+[prek]: https://prek.j178.dev
 
 <!-- prettier-ignore-end -->
 


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

- Add tabs for prek and pre-commit in gha_basic.md with prek first
- Reorder tabs in style.md to put prek before pre-commit
- Add link definitions for pre-commit and prek
- Add tabs.js script to gha_basic.md
- Fix typo in style.md (hanges -> changes)

Assisted-by: OpenCode:qwen3.5:397B

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--791.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->