### PR TITLE
fix: add a few more formatters/linters for markdown

### DIFF
--- a/src/sp_repo_review/checks/precommit.py
+++ b/src/sp_repo_review/checks/precommit.py
@@ -149,6 +149,9 @@ class PC180(PreCommit):
         "https://github.com/hukkin/mdformat",
         "https://github.com/rvben/rumdl-pre-commit",
         "https://github.com/davidanson/markdownlint-cli2",
+        "https://github.com/jolars/panache-pre-commit",
+        "https://github.com/akiomik/mado",
+        "https://github.com/markdownlint/markdownlint",
     }
 
 


### PR DESCRIPTION
Adding a few more from https://panache.bz/guide/comparison which I noticed in https://github.com/rvben/rumdl/issues/584.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--793.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->