### PR TITLE
fix: use hyphenated page slugs in internal doc links

### DIFF
--- a/docs/pages/guides/gha_pure.md
+++ b/docs/pages/guides/gha_pure.md
@@ -27,7 +27,7 @@ reasons that a wheel is better than only providing an sdist:
   is going to go
 :::
 
-[on the next page]: pages/guides/gha_wheels
+[on the next page]: pages/guides/gha-wheels
 
 ### Job setup
 

--- a/docs/pages/guides/index.md
+++ b/docs/pages/guides/index.md
@@ -42,15 +42,15 @@ WebAssembly! All checks point to a linked badge in the guide.
 [style]:              pages/guides/style
 [mypy]:               pages/guides/mypy
 [docs]:               pages/guides/docs
-[simple packaging]:   pages/guides/packaging_simple
-[compiled packaging]: pages/guides/packaging_compiled
-[classic packaging]:  pages/guides/packaging_classic
+[simple packaging]:   pages/guides/packaging-simple
+[compiled packaging]: pages/guides/packaging-compiled
+[classic packaging]:  pages/guides/packaging-classic
 [coverage]:           pages/guides/coverage
-[gha_basic]:          pages/guides/gha_basic
-[gha_pure]:           pages/guides/gha_pure
-[gha_wheels]:         pages/guides/gha_wheels
+[gha_basic]:          pages/guides/gha-basic
+[gha_pure]:           pages/guides/gha-pure
+[gha_wheels]:         pages/guides/gha-wheels
 [pytest]:             pages/guides/pytest
-[right in the guide]: pages/guides/repo_review
+[right in the guide]: pages/guides/repo-review
 
 [cookiecutter]:             https://cookiecutter.readthedocs.io
 [copier]:                   https://copier.readthedocs.io

--- a/docs/pages/guides/packaging_classic.md
+++ b/docs/pages/guides/packaging_classic.md
@@ -12,7 +12,7 @@ outlined as well.
 There are several popular packaging systems. This guide covers the old
 configuration style for [Setuptools][]. Unless you really need it, you should be
 using the modern style described in [Simple
-Packaging](pages/guides/packaging_simple). The modern style is
+Packaging](pages/guides/packaging-simple). The modern style is
 guided by Python Enhancement Proposals (PEPs), and is more stable than the
 setuptools-specific mechanisms that evolve over the years. This page is kept to
 help users with legacy code (and hopefully upgrade it).

--- a/docs/pages/guides/packaging_compiled.md
+++ b/docs/pages/guides/packaging_compiled.md
@@ -44,7 +44,7 @@ The most exciting developments have been new native build backends:
 
 :::{note}
 You should be familiar with [packing a pure Python
-project](pages/guides/packaging_compiled) - the metadata
+project](pages/guides/packaging-compiled) - the metadata
 configuration is the same.
 :::
 There are also classic setuptools plugins:
@@ -457,4 +457,4 @@ it is free-threaded. 3.13.5 was rushed out to fix it.
 [meson-python]: https://meson-python.readthedocs.io
 [setuptools-rust]: https://setuptools-rust.readthedocs.io/en/latest/
 [maturin]: https://www.maturin.rs
-[gha_wheels]: pages/guides/gha_wheels
+[gha_wheels]: pages/guides/gha-wheels

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -75,14 +75,14 @@ with many updates. Improved support for compiled components supported in part
 by NSF grant [OAC-2209877][].
 :::
 
-[simple]:                   pages/guides/packaging_simple
-[compiled]:                 pages/guides/packaging_compiled
+[simple]:                   pages/guides/packaging-simple
+[compiled]:                 pages/guides/packaging-compiled
 [style checking]:           pages/guides/style
 [testing]:                  pages/guides/pytest
 [documentation]:            pages/guides/docs
 [static typing]:            pages/guides/mypy
-[ci]:                       pages/guides/gha_pure
-[right in the guide]:       pages/guides/repo_review
+[ci]:                       pages/guides/gha-pure
+[right in the guide]:       pages/guides/repo-review
 
 [scientific-python/cookie]: https://github.com/scientific-python/cookie
 [repo-review]:              https://repo-review.readthedocs.io

--- a/docs/pages/patterns/index.md
+++ b/docs/pages/patterns/index.md
@@ -14,7 +14,7 @@ If you would like to use backport packages, see [Backports][].
 
 If you are wondering about public API, see [Exports][].
 
-[including data files]: pages/patterns/data_files
+[including data files]: pages/patterns/data-files
 [backports]: pages/patterns/backports
 [exports]: pages/patterns/exports
 

--- a/docs/pages/tutorials/packaging.md
+++ b/docs/pages/tutorials/packaging.md
@@ -129,4 +129,4 @@ In [1]: snell?
 For more about packaging, also see our [packaging guide][].
 
 [version control with git]: https://swcarpentry.github.io/git-novice/
-[packaging guide]: pages/guides/packaging_simple
+[packaging guide]: pages/guides/packaging-simple


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Update all internal MyST link references to use hyphens instead of underscores to match the actual page filenames:

- `packaging_simple` → `packaging-simple`
- `packaging_compiled` → `packaging-compiled`
- `packaging_classic` → `packaging-classic`
- `gha_basic` → `gha-basic`
- `gha_pure` → `gha-pure`
- `gha_wheels` → `gha-wheels`
- `repo_review` → `repo-review`
- `data_files` → `data-files`

These links were referencing pages with underscores but the actual filenames use hyphens, so the links would have been broken.

Assisted-by: OpenCode:glm-5

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--796.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->