### PR TITLE
ci: adopt zizmor for this repo's own workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -18,7 +18,12 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Scope the token to only what the PR creation needs
+          permission-contents: write
+          permission-pull-requests: write
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@v8.2.0
       - run: uvx nox -s pc_bump
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,14 +6,19 @@ on:
     types:
       - published
 
+permissions: {}
+
 jobs:
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: hynek/build-and-inspect-python-package@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,23 +11,34 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   change-detection:
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/reusable-change-detection.yml
 
   cookie:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cookie)
+    permissions:
+      contents: read
     uses: ./.github/workflows/reusable-cookie.yml
 
   rr-tests:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-rr)
+    permissions:
+      contents: read
     uses: ./.github/workflows/reusable-rr-tests.yml
 
   docs:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-docs)
+    permissions:
+      contents: read
     uses: ./.github/workflows/reusable-docs.yml
 
   pass:

--- a/.github/workflows/docs-link.yml
+++ b/.github/workflows/docs-link.yml
@@ -1,6 +1,9 @@
 name: Read the Docs PR preview
 
 on:
+  # zizmor: ignore[dangerous-triggers]
+  # pull_request_target is required so the RTD preview can comment on PRs from
+  # forks; no untrusted code is checked out, and it is gated on `fork == false`.
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -23,6 +23,8 @@ jobs:
       run-docs: ${{ steps.docs-changes.outputs.run-docs || false }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Changed cookie-related files
         if: github.event_name == 'pull_request'

--- a/.github/workflows/reusable-cookie.yml
+++ b/.github/workflows/reusable-cookie.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Lint all
         run: pipx run nox -s 'lint'
@@ -33,6 +35,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v6
         with:
@@ -105,6 +109,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v6
         with:
@@ -172,6 +178,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Build sdist and wheel
         run: pipx run nox -s dist

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -10,6 +10,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@v2
 

--- a/.github/workflows/reusable-rr-tests.yml
+++ b/.github/workflows/reusable-rr-tests.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: actions/setup-python@v6
@@ -41,6 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Run sp-repo-review action
@@ -52,6 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: actions/setup-python@v6
@@ -71,6 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: actions/setup-python@v6

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+# Configuration for zizmor (https://docs.zizmor.sh)
+rules:
+  unpinned-uses:
+    config:
+      # Actions are kept up to date with Dependabot, so a ref (tag) pin is
+      # sufficient; hash pinning is not required.
+      policies:
+        "*": ref-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,11 @@ repos:
       - id: typos
         exclude: ^Gemfile\.lock$
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: "v1.25.2"
+    hooks:
+      - id: zizmor
+
   - repo: local
     hooks:
       - id: disallow-caps

--- a/action.yml
+++ b/action.yml
@@ -28,14 +28,21 @@ runs:
 
     - name: Run repo-review
       shell: bash
+      # Pass expansions through the environment to avoid template injection
+      env:
+        PYTHON_PATH: ${{ steps.python.outputs.python-path }}
+        ACTION_PATH: ${{ github.action_path }}
+        SELECT: ${{ inputs.select }}
+        IGNORE: ${{ inputs.ignore }}
+        PACKAGE_DIR: ${{ inputs.package-dir }}
       run: >
         pipx run
-        --python '${{ steps.python.outputs.python-path }}'
-        --spec '${{ github.action_path }}[cli]'
+        --python "$PYTHON_PATH"
+        --spec "$ACTION_PATH[cli]"
         repo-review .
         --format html
         --stderr rich
-        --select "${{ inputs.select }}"
-        --ignore "${{ inputs.ignore }}"
-        --package-dir "${{ inputs.package-dir }}"
-        >> $GITHUB_STEP_SUMMARY
+        --select "$SELECT"
+        --ignore "$IGNORE"
+        --package-dir "$PACKAGE_DIR"
+        >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up to #798: adopts [zizmor](https://docs.zizmor.sh) for this repo's own GitHub Actions and makes everything zizmor-clean. (This is the "full dogfooding" deferred in #798; once both land, `GH106` can be un-ignored here.)

## Setup
- Adds the `zizmor` pre-commit hook.
- Adds `.github/zizmor.yml` relaxing `unpinned-uses` to `ref-pin` (actions are kept current via Dependabot, so hash pins aren't required).

## Fixes
- **excessive-permissions**: top-level `permissions: {}` with minimal per-job grants in `ci.yml` (reusable-workflow callers get `contents: read`, change-detection also `pull-requests: read`) and `cd.yml` (`dist` gets `contents: read`).
- **artipacked**: `persist-credentials: false` on every checkout.
- **template-injection**: `action.yml` now passes inputs (`select`, `ignore`, `package-dir`, action path, python path) through `env:` and references shell variables instead of interpolating `${{ }}` into the `run:` script.
- **github-app**: the bump bot's `create-github-app-token` is scoped to `permission-contents: write` + `permission-pull-requests: write`.
- **dependabot-cooldown**: added a 7-day `cooldown` for the github-actions ecosystem.

## Documented ignore
- **dangerous-triggers**: `docs-link.yml` keeps `pull_request_target` (required for the Read the Docs preview to comment on PRs from forks) with an inline `# zizmor: ignore[dangerous-triggers]` — no untrusted code is checked out and it's gated on `fork == false`.

## Validation
`zizmor` reports "No findings" across all workflows + `action.yml`, and `prek -a` (including the new zizmor hook) passes.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--799.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->