### PR TITLE
docs: fix factual errors, inconsistencies, and typos in the guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,7 @@ Thumbs.db
 # Common editor files
 *~
 *.swp
+
+# Symlink to AGENTS.md
+CLAUDE.md
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/pages/guides/coverage.md
+++ b/docs/pages/guides/coverage.md
@@ -137,7 +137,7 @@ your jobs and combine them into one `.coverage` file before running
 
 ##### Manually combining coverage
 
-If you are running in parallel, either with `pytest-xdist`, you can set
+If you are running in parallel, such as with `pytest-xdist`, you can set
 `run.parallel` to `true`, which will add a unique suffix to the coverage file(s)
 produced. If you are using the multiprocessing patch, that also will generate a
 unique suffix for each process launch.

--- a/docs/pages/guides/docs.md
+++ b/docs/pages/guides/docs.md
@@ -17,7 +17,7 @@ commonly used, and have somewhat fewer examples and plugins. They are:
   framework for scientific libraries with a history of close usage with
   scientific tools like LaTeX. Examples include
   [astropy](https://docs.astropy.org/en/stable/index_user_docs.html) and
-  [corner](https://docs.astropy.org/en/stable/index_user_docs.html).
+  [corner](https://corner.readthedocs.io).
 - [MkDocs](https://www.mkdocs.org): A from-scratch new documentation system
   based on markdown and HTML. Less support for man pages & PDFs than Sphinx,
   since it doesn't use docutils. Has over

--- a/docs/pages/guides/docs.md
+++ b/docs/pages/guides/docs.md
@@ -10,8 +10,8 @@ the same format used by GitHub, Wikipedia, and others. This guide covers Sphinx
 and Mkdocs, and uses the modern MyST plugin to get Markdown support.
 
 :::{note} Popular frameworks
-There are other frameworks as well; these often are simpler, but are not as
-commonly used, and have somewhat fewer examples and plugins. They are:
+The two frameworks covered in this guide are the most commonly used in the
+scientific Python community. The main options are:
 
 - [Sphinx](https://www.sphinx-doc.org/en/master/): A popular documentation
   framework for scientific libraries with a history of close usage with
@@ -197,7 +197,7 @@ several good extensions:
 - [`sphinx.ext.napoleon`][] adds support for several common documentation styles
   like numpydoc.
 - `sphinx_autodoc_typehints` handles type hints
-- `sphinx_copybutton` adds a handle little copy button to code snipits.
+- `sphinx_copybutton` adds a handy little copy button to code snippets.
 
 We are including both possible file extensions. We are also avoiding some common
 file patterns, just in case.
@@ -602,9 +602,9 @@ some conditional installs based on arguments (sphinx-autobuild is only needed if
 serving). It does an editable install of your package so that you can skip the
 install steps with `-R` and still get updated documentation.
 
-Then there's a dedicated handler for the 'linkcheck' builder, which just checks
-links, and doesn't really produce output. Finally, we collect some useful args,
-and run either the autobuild (for `--serve`) or regular build. We could have
+The `-b` argument selects the builder, so you can pass `-b linkcheck` to just
+check links, for example. Finally, we collect some useful args, and run either
+the autobuild (when interactive) or a regular build. We could have
 just added `python -m http.server` pointing at the built documentation, but
 autobuild will rebuild if you change a file while serving.
 :::

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -226,7 +226,7 @@ actions have outputs, and bash actions can manually write to output:
 ```
 
 You can now refer to this step in a later step with
-`${{ steps.someid.something }}`. You also can get it from another job by using
+`${{ steps.someid.outputs.something }}`. You also can get it from another job by using
 `${{ needs.<jobname>.outputs.something }}`. The `toJson()` function is useful
 for inputting JSON - you can even generate matrices dynamically this way!
 

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -226,9 +226,9 @@ actions have outputs, and bash actions can manually write to output:
 ```
 
 You can now refer to this step in a later step with
-`${{ steps.someid.outputs.something }}`. You also can get it from another job by using
-`${{ needs.<jobname>.outputs.something }}`. The `toJson()` function is useful
-for inputting JSON - you can even generate matrices dynamically this way!
+`${{ steps.someid.outputs.something }}`. You also can get it from another job by
+using `${{ needs.<jobname>.outputs.something }}`. The `toJson()` function is
+useful for inputting JSON - you can even generate matrices dynamically this way!
 
 #### Pretty output
 

--- a/docs/pages/guides/gha_pure.md
+++ b/docs/pages/guides/gha_pure.md
@@ -46,7 +46,7 @@ jobs:
 This will run when you manually trigger a build ([`workflow_dispatch`][]), or
 when you publish a release. Later, we will make sure that the actual publish
 step requires the event to be a publish event, so that manual triggers (and
-branches/PRs, if those are enabled).
+branches/PRs, if those are enabled) do not publish to PyPI.
 
 If you want tags instead of releases, you can add the `on: push: tags: "v*"` key
 instead of the releases - however, _please_ remember to make a GitHub release of

--- a/docs/pages/guides/gha_wheels.md
+++ b/docs/pages/guides/gha_wheels.md
@@ -24,9 +24,9 @@ on:
   release:
     types:
       - published
-    pull_request:
-      paths:
-        - .github/workflows/cd.yml
+  pull_request:
+    paths:
+      - .github/workflows/cd.yml
 ```
 
 This will run on releases. If you use a develop branch, you could include
@@ -55,7 +55,7 @@ build-verbosity = 1
 ```
 
 The build frontend is set to `build[uv]`, which is faster than the default build
-backend; you just need uv installed, but that's easy to do. The `test-extras`
+backend; you just need uv installed, but that's easy to do. The `test-groups`
 will cause the pip install to use the dependency-group(s) specified. The
 `test-command` will use pytest to run your tests. You can also set the build
 verbosity (`-v` in pip) if you want to.

--- a/docs/pages/guides/index.md
+++ b/docs/pages/guides/index.md
@@ -19,10 +19,10 @@ which should help in ensuring a consistent developer and user experience when
 working with distribution.
 
 A section on CI follows, with a [general setup guide][gha_basic], and then two
-choices for using CI to distribute your package, on for [pure Python][gha_pure],
-and one for [compiled extensions][gha_wheels]. You can read about setting up
-good tests on the [pytest page][pytest], with [coverage][]. There's also a page
-on setting up [docs][], as well.
+choices for using CI to distribute your package, one for
+[pure Python][gha_pure], and one for [compiled extensions][gha_wheels]. You can
+read about setting up good tests on the [pytest page][pytest], with
+[coverage][]. There's also a page on setting up [docs][], as well.
 
 :::{tip} New project template
 Once you have completed the guidelines, there is a

--- a/docs/pages/guides/mypy.md
+++ b/docs/pages/guides/mypy.md
@@ -127,7 +127,7 @@ from typing import Protocol
 
 
 class Duck(Protocol):
-    def quack() -> str: ...
+    def quack(self) -> str: ...
 ```
 
 Now any object that can "quack" (and return a string) is a Duck. We can even add
@@ -145,7 +145,7 @@ we can write a duck implementation and test it like this:
 
 ```python
 class MyDuck:
-    def quack() -> str:
+    def quack(self) -> str:
         return "quack"
 ```
 

--- a/docs/pages/guides/packaging_compiled.md
+++ b/docs/pages/guides/packaging_compiled.md
@@ -44,7 +44,7 @@ The most exciting developments have been new native build backends:
 
 :::{note}
 You should be familiar with [packing a pure Python
-project](pages/guides/packaging-compiled) - the metadata
+project](pages/guides/packaging-simple) - the metadata
 configuration is the same.
 :::
 There are also classic setuptools plugins:

--- a/docs/pages/guides/packaging_simple.md
+++ b/docs/pages/guides/packaging_simple.md
@@ -109,7 +109,7 @@ the installed version - this obviously tends to break if you build parts of the
 library or if you access package metadata.
 
 This sadly is not part of the standard metadata in `[project]`, so it depends on
-what backend you you use. Hatchling, Flit, PDM, and setuptools use automatic
+what backend you use. Hatchling, Flit, PDM, and setuptools use automatic
 detection.
 
 If you don't match your package name and import name (which you should except

--- a/docs/pages/guides/packaging_simple.md
+++ b/docs/pages/guides/packaging_simple.md
@@ -94,7 +94,7 @@ build-backend = "setuptools.build_meta"
 ```
 
 For `requires-python`, you should specify the minimum you require, and you
-should not put an upper cap on it {rr}`PY004`, as this field is used to
+should not put an upper cap on it {rr}`PP004`, as this field is used to
 back-solve for old package versions that pass this check, allowing you to safely
 drop Python versions.
 

--- a/docs/pages/guides/pytest.md
+++ b/docs/pages/guides/pytest.md
@@ -105,7 +105,7 @@ summary "r"eport of "a"ll results, which gives you a quick way to review what
 tests failed and were skipped, and why. `--showlocals` will print locals in
 tracebacks - depending on your tests, you might or might not like this one.
 {rr}`PP307` `--strict-markers` will make sure you don't try to use an
-unspecified fixture. {rr}`PP306` And `--strict-config` will error if you make
+unspecified marker. {rr}`PP306` And `--strict-config` will error if you make
 a mistake in your config. {rr}`PP305` `xfail_strict` will change the default
 for `xfail` to fail the tests if it doesn't fail - you can still override
 locally in a specific xfail for a flaky failure. {rr}`PP309`
@@ -198,7 +198,7 @@ from pytest import approx
 
 
 def test_approx():
-    0.3333333333333 == approx(1 / 3)
+    assert 0.3333333333333 == approx(1 / 3)
 ```
 
 This natively works with NumPy arrays, too! Always prefer
@@ -296,7 +296,7 @@ pytest to run a group of marked tests. This is an expression; you can use
 Probably the most useful built-in mark is `skipif`:
 
 ```python
-@pytest.mark.skipif("sys.version_info >= (3, 8)")
+@pytest.mark.skipif("sys.version_info < (3, 8)")
 def test_only_on_38plus():
     x = 3
     assert f"{x = }" == "x = 3"

--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -422,10 +422,10 @@ ignore. New checks go into `--preview` before being activated in a minor
 release.
 
 :::{dropdown} You can add a Ruff badge to your repo as well
-[![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json))](https://github.com/astral-sh/ruff)
+[![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 ```md
-[![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json))](https://github.com/astral-sh/ruff)
+[![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 ```
 
 ```rst
@@ -509,7 +509,7 @@ enable more checks. A few interesting plugins:
   Enforces PEP8 grouped imports (you may prefer isort). Code: `I`
 - [`pep8-naming`](https://pypi.org/project/pep8-naming/): Enforces PEP8 naming
   rules. Code: `N`
-- [`flake8-print`](https://pypi.org/project/pep8-naming/): Makes sure you don't
+- [`flake8-print`](https://pypi.org/project/flake8-print/): Makes sure you don't
   have print statements that sneak in. Code: `T`
 
 :::{dropdown} Flake8-print details

--- a/docs/pages/guides/tasks.md
+++ b/docs/pages/guides/tasks.md
@@ -48,7 +48,7 @@ but tox and hatch both are also acceptable.
 Nox doesn't handle binary builds very well, so for compiled projects, it might
 be best left to just specialized tasks.
 
-[hatch]: https://hatch.pypi.io
+[hatch]: https://hatch.pypa.io
 [nox]: https://nox.thea.codes
 [tox]: https://tox.readthedocs.io
 [invoke]: https://www.pyinvoke.org

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -11,8 +11,8 @@ fellow scientists and research software engineers.
 
 **Start at the basics.** Do you have a pile of scientific Python scripts or
 Jupyter notebooks that are becoming unwieldy? Are changes to some parts of your
-code accidentally breaking other parts of your code? Do you want to more
-maintainable, reusable, and shareable form? Start at the
+code accidentally breaking other parts of your code? Do you want to present them
+in a more maintainable, reusable, and shareable form? Start at the
 [tutorial](pages/tutorials/index).
 
 **Learn recommended tools and best practices.**

--- a/docs/pages/patterns/backports.md
+++ b/docs/pages/patterns/backports.md
@@ -57,7 +57,7 @@ advantages:
   manually look at the output of `git grep "sys.version_info"` to clean these
   up.
 - You can select the specific version of Python to switch on, even if the import
-  was available sooner. In this case, `import.metadata` was added in 3.8 but
+  was available sooner. In this case, `importlib.metadata` was added in 3.8 but
   important fixes landed in 3.10.
 - It matches your conditional requirements.
 
@@ -114,7 +114,7 @@ backport re-export file.
 - `importlib_resources`: Added as `importlib.resources` in 3.7, important
   updates in 3.9 (`files` added, which is the recommended public API!).
 - `tomli`: Added as `tomllib` in 3.11. Likely to become important again when
-  TOML 1.1 is released. (Note that `toml_w` is not in the stdlib.)
+  TOML 1.1 is released. (Note that `tomli_w` is not in the stdlib.)
 - `exceptiongroup`: A new builtin (`ExceptionGroup`) in 3.11.
-- `tz-data`: A first-party PyPI version of `zoneinfo` from 3.9, though with more
-  up-to-date timezone info.
+- `tzdata`: A first-party PyPI version of the data used by `zoneinfo` (added in
+  3.9), though with more up-to-date timezone info.

--- a/docs/pages/patterns/data_files.md
+++ b/docs/pages/patterns/data_files.md
@@ -85,7 +85,7 @@ Let's put them in a new directory in our package, such as
 ```
 
 To make these available to the Python loading mechanism, the easiest way is to
-add an `__init__.py` in `src/package/peak_spacing`. This can be an empty file;
+add an `__init__.py` in `src/package/peak_spacings`. This can be an empty file;
 it's purpose is to tell Python that this can be loaded.
 
 You'll want to make sure your Python building backend is placing these files in
@@ -155,7 +155,7 @@ LaB6 = files / "LaB6.txt"
 # Provide whatever is useful for your project here
 ```
 
-Now, a user can simply import and use `package.peakspacing.LaB6` and such
+Now, a user can simply import and use `package.peak_spacings.LaB6` and such
 directly.
 
 ### Downloading larger files on demand

--- a/docs/pages/principles/design.md
+++ b/docs/pages/principles/design.md
@@ -71,8 +71,8 @@ analysis tools can't tell you if you forget a step, the API doesn't statically
 implicit changing state, and not all operations are valid in all possible
 states.
 
-One alternative replace `Data` with multiple immutable classes representing the
-state at each step.
+One alternative is to replace `Data` with multiple immutable classes
+representing the state at each step.
 
 ```python
 empty_data = EmptyData()

--- a/docs/pages/principles/testing.md
+++ b/docs/pages/principles/testing.md
@@ -15,7 +15,7 @@ perspective of your users, focusing on the behavior of the public interface and
 the Features that your project provides. Then we will cover
 [Project Level Integration tests](#project-level-integration-tests), which test
 that the various parts of your package work together, and work with the other
-packages it depends on. Finally we will cover the venrable
+packages it depends on. Finally we will cover the venerable
 {ref}`Unit Test <unit-tests>`, which test the correctness of your code from a
 perspective internal to your codebase, tests individual units in isolation, and
 are optimized to run quickly and often.
@@ -367,7 +367,7 @@ def test_func(mocker):
 Consider the benefits of refactoring your imports like so:
 
 ```python
-from numpy import sum as np_sum, Array as NpArray
+from numpy import sum as np_sum, ndarray as NpArray
 ```
 
 now you simply need to patch the imported function in the context of the
@@ -675,7 +675,7 @@ from unittest.mock import patch, Mock
 SRC = "mymodule.path.to.source"
 
 
-@patch(f"{SRC}.patchme", autospec=true)
+@patch(f"{SRC}.patchme", autospec=True)
 def test_myfunction(t, patchme: Mock):
     ret = myfunction()
     patchme.assert_called_with("input from myfunction")

--- a/docs/pages/tutorials/docs.md
+++ b/docs/pages/tutorials/docs.md
@@ -136,7 +136,7 @@ We can link them from the front page by using the MyST Markdown `{toctree}`
 directive.
 
 ````markdown
-```text {toctree}
+```{toctree}
 tutorials/installation.md
 tutorials/first-steps.md
 tutorials/real-application.md
@@ -154,7 +154,7 @@ or drifting out of sync over time.
 
 MyST recommends using [sphinx-autodoc2][]. However, we currently recommend using
 the built-in sphinx `autodoc` and `autosummary` extensions because they
-interoperates well with docstrings written to the numpydoc standard. To invoke
+interoperate well with docstrings written to the numpydoc standard. To invoke
 them, we need to employ yet another syntax (reST). Fortunately, you can simply
 copy/paste these examples.
 

--- a/docs/pages/tutorials/packaging.md
+++ b/docs/pages/tutorials/packaging.md
@@ -111,7 +111,7 @@ function.
 >>> from example.refraction import snell
 >>> import numpy as np
 >>> snell(np.pi / 4, 1.00, 1.33)
-1.2239576240104186
+0.5605584137424605
 ```
 
 The docstring can be viewed with `help()`.

--- a/docs/pages/tutorials/test.md
+++ b/docs/pages/tutorials/test.md
@@ -40,9 +40,9 @@ example
 ├── src
 │   └── example
 │       ├── __init__.py
-│       └── rescale.py
+│       └── refraction.py
 └── tests
-    └── test_rescale.py
+    └── test_snell.py
 ```
 
 > You may also see some `__pycache__` directories, which contain compiled Python
@@ -84,9 +84,8 @@ Things to notice:
 
 - It is tempting to put multiple assert statements in one test, but try to
   resist. You should make a separate test for each behavior that you are
-  checking, as pytest will only report the first test, which gives you an
-  incomplete picture of the failure. This is often referred to as the
-  Arrange-Act-Assert pattern.
+  checking, since a test stops at the first failing assertion, which gives you
+  an incomplete picture if a later behavior is also broken.
 - When comparing floating-point numbers (as opposed to integers) you should not
   test for exact equality. `pytest.approx` supports fuzzy comparisons and
   supports NumPy arrays.
@@ -123,11 +122,11 @@ platform darwin -- Python 3.6.4, pytest-3.6.2, py-1.5.4, pluggy-0.6.0
 benchmark: 3.1.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
 rootdir: /private/tmp/test11/example, inifile:
 plugins: pep8-1.0.6, lazy-fixture-0.3.0, forked-0.2, benchmark-3.1.1
-collected 1 item
+collected 3 items
 
-example/tests/test_snell.py ..                                                                 [100%]
+tests/test_snell.py ...                                                                        [100%]
 
-===================================== 2 passed in 0.02 seconds ======================================
+===================================== 3 passed in 0.02 seconds ======================================
 ```
 
 The output of `pytest` is customizable. Commonly useful command-line arguments


### PR DESCRIPTION
Ran Opus on the guide. It actually ran in one go (the other two sites I did it fanned out), so maybe I should have tried Fable.

Also added `CLAUDE.md` to the gitignore (it should just be a symlink to `AGENTS.md`, Claude Code is the only harness not to follow the standard).

:robot: _AI text below_ :robot:

Review of `docs/pages/` turned up a batch of concrete errors. Split into two commits: factual/code fixes first, then typos/grammar.

## Commit 1 — factual / code errors & inconsistencies

These would actively mislead a reader who copied the snippets:

- **packaging tutorial**: wrong `snell(np.pi/4, 1.00, 1.33)` output (`1.2239576240104186` → `0.5605584137424605`, the value the other two pages already use)
- **pytest guide**: inverted `skipif` condition; `--strict-markers` described as checking fixtures (it's markers); missing `assert` in the `approx` example
- **packaging-simple**: requires-python upper-cap check is `PP004`, not `PY004` (`PY004` is "has docs folder")
- **packaging-compiled**: "pure Python project" link pointed at itself instead of packaging-simple
- **gha-basic**: step-output reference missing `.outputs.`
- **gha-wheels**: mis-indented `pull_request` trigger (was nested under `release:`); `test-extras` → `test-groups`
- **tasks**: broken hatch URL (`hatch.pypi.io` → `hatch.pypa.io`)
- **style**: wrong `flake8-print` URL; stray `)` in the Ruff v2 badge
- **docs**: `corner` example link pointed at astropy
- **data-files**: unified the `peak_spacings` directory name (was drifting between `peak_spacing`/`peakspacing`)
- **test tutorial**: aligned dir tree + pytest output with the snell example; dropped an incorrect Arrange-Act-Assert reference

## Commit 2 — typos & grammar

Broken intro sentence on the home page, "on for"→"one for", "you you use", a dangling "either with", an incomplete sentence in gha-pure, "snipits"→"snippets", a reframed (self-contradictory) "Popular frameworks" note, stale linkcheck-handler prose, missing `self` on Protocol methods, `importlib.metadata`/`tomli_w`/`tzdata` fixes, `autospec=True`, numpy `ndarray`, and a malformed `{toctree}` fence.

`rumdl` and `prettier` pass on the changed files.

Left untouched: the forward-looking pytest 9+ config block (`[tool.pytest]` with `strict = true`) — speculative future syntax rather than a clear error.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--800.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->