### PR TITLE
fix(docs): restore site footer after mystmd conversion

### DIFF
--- a/docs/config/scientific-python.yml
+++ b/docs/config/scientific-python.yml
@@ -2,6 +2,8 @@ version: 1
 
 site:
   template: book-theme
+  parts:
+    footer: footer.md
   options:
     hide_toc: false
     hide_footer_links: true

--- a/docs/footer.md
+++ b/docs/footer.md
@@ -1,0 +1,38 @@
+<!-- rumdl-disable MD041 -->
+
+% This defines the site-wide footer; it is not parsed as a regular "page".
+% It is wired up in `config/scientific-python.yml`:
+% site:
+% parts:
+% footer: footer.md
+% The column layout is controlled by `.footer .outer-grid` in
+% `assets/css/site.css` (grid-template-columns: 3fr 3fr 4fr).
+
+:::::{grid} 1 1 3 3
+:class: outer-grid col-screen
+
+<!-- Project description -->
+
+::::{div}
+
+# Scientific Python Development Guide
+
+This guide is maintained by the scientific Python community for the benefit of
+fellow scientists and research software engineers.
+::::
+
+<!-- Spacer between description and links -->
+
+::::{div}
+::::
+
+<!-- Links -->
+
+::::{div}
+
+- [Scientific Python](https://scientific-python.org)
+- [Learn](https://learn.scientific-python.org)
+- [Source on GitHub](https://github.com/scientific-python/cookie)
+  ::::
+
+:::::


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

After the move to mystmd (#792), the site footer is missing and there is "no site title".

## Root cause

The migration ported the footer **styling** (`docs/assets/css/site.css` has the full `.footer` / `.outer-grid` block, including the site-title `h1` rule) but never ported the footer **content**. In the book-theme the site-wide footer is a *content part* wired via:

```yaml
site:
  parts:
    footer: footer.md
```

`docs/config/scientific-python.yml` had no `parts:` section at all, so MyST rendered no `<footer>` element — and the site title that lives inside the footer disappeared with it. (The top-left header logo + `logo_text` were always rendering; the "footer-link" classes in the HTML are just the prev/next page nav, not the site footer.)

## Fix

- `docs/config/scientific-python.yml` — add the missing `parts.footer: footer.md` wiring, mirroring the upstream `scientific-python-myst-theme` config.
- `docs/footer.md` (new) — footer content using the `.outer-grid` grid the CSS already expects: site-title `h1`, the maintainer blurb, and the Scientific Python / Learn / Source links. It starts with a MyST `%` comment (not a real page), so it carries `<!-- rumdl-disable MD041 -->`, the same inline-disable pattern already used in `docs/_partials/pyproject.md`.

## Verification

`npx myst build --html` now emits a `<footer>` with the dark teal background, the site-title `h1`, the description, and the links. `prek` (rumdl) passes on both files.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--801.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->