### PR TITLE
feat(checks): accept ty in PC140 type checker check

### DIFF
--- a/src/sp_repo_review/checks/precommit.py
+++ b/src/sp_repo_review/checks/precommit.py
@@ -118,6 +118,7 @@ class PC140(PreCommit):
     repos = {
         "https://github.com/pre-commit/mirrors-mypy",
         "https://github.com/facebook/pyrefly-pre-commit",
+        "https://github.com/astral-sh/ty-pre-commit",
     }
 
 

--- a/tests/test_precommit.py
+++ b/tests/test_precommit.py
@@ -142,6 +142,14 @@ def test_pc140_pyrefly():
     assert compute_check("PC140", precommit=precommit).result
 
 
+def test_pc140_ty():
+    precommit = yaml.safe_load("""
+        repos:
+          - repo: https://github.com/astral-sh/ty-pre-commit
+    """)
+    assert compute_check("PC140", precommit=precommit).result
+
+
 def test_pc160_codespell():
     precommit = yaml.safe_load("""
         repos:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds [`astral-sh/ty-pre-commit`](https://github.com/astral-sh/ty-pre-commit) as an accepted type checker hook in the `PC140` check, alongside the existing mypy and pyrefly support.

- `src/sp_repo_review/checks/precommit.py`: add the ty repo to `PC140.repos`
- `tests/test_precommit.py`: add `test_pc140_ty` mirroring the pyrefly test

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--804.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->