### PR TITLE
fix(docs): remove duplicate page titles after mystmd conversion

### DIFF
--- a/docs/_partials/pyproject.md
+++ b/docs/_partials/pyproject.md
@@ -1,4 +1,6 @@
-# pyproject.toml: project table
+<!-- rumdl-disable MD041 -->
+
+## pyproject.toml: project table
 
 <!-- [[[cog
 from cog_helpers import code_fence, render_cookie, TOMLMatcher
@@ -64,7 +66,7 @@ special, and replaces the old url setting.
 If you use the above configuration, you need `README.md` and `LICENSE` files,
 since they are explicitly specified.
 
-## License
+### License
 
 The license can be done one of two ways.
 
@@ -91,7 +93,7 @@ classifiers = [
 You should not include the `License ::` classifiers if you use the `license`
 field {rr}`PP007`.
 
-### Extras
+#### Extras
 
 Sometimes you want to ship a package with optional dependencies. For example,
 you might have extra requirements that are only needed for running a CLI, or for
@@ -113,7 +115,7 @@ mpl = [
 Self dependencies can be used by using the name of the package, such as
 `all = ["package[cli,mpl]"]`, (requires Pip 21.2+).
 
-### Command line
+#### Command line
 
 If you want to ship an "app" that a user can run from the command line, you need
 to add a `script` entry point. The form is:
@@ -128,7 +130,7 @@ function, followed by a colon, then the function to call. If you use
 `__main__.py` as the file, then `python -m` followed by the module will also
 work to call the app (`__name__` will be `"__main__"` in that case).
 
-### Development dependencies
+#### Development dependencies
 
 The proper way to specify dependencies exclusively used for development tasks
 (such as `pytest`, `ruff`, packages for generating documentation, etc.) is to

--- a/docs/pages/guides/coverage.md
+++ b/docs/pages/guides/coverage.md
@@ -1,8 +1,4 @@
----
-title: "Code coverage"
----
-
-## Code Coverage
+# Code Coverage
 
 The "Code coverage" value of a codebase indicates how much of the
 production/development code is covered by the running unit tests. Maintainers
@@ -32,7 +28,7 @@ adding weak tests just for coverage's sake is not a good idea. The tests
 should test your codebase thoroughly and should not be unreliable.
 :::
 
-### Running your tests with coverage
+## Running your tests with coverage
 
 There are two common ways to calculate coverage: using `coverage` or using
 `pytest-cov`. While `pytest-cov` is simpler on the command line, and it promises
@@ -92,7 +88,7 @@ shown below.
 :::
 ::::
 
-#### Configuring coverage
+### Configuring coverage
 
 There is a configuration section in `pyproject.toml` for coverage. Here are some
 common options
@@ -126,7 +122,7 @@ There are also useful reporting options. `report.exclude_lines = [...]` allows
 you to exclude lines from coverage. `report.fail_under` can trigger a failure if
 coverage is below a percent (like 100).
 
-#### Calculating code coverage in your workflows
+### Calculating code coverage in your workflows
 
 Your workflows should produce a `.coverage` file as outlined above. This file
 can be uploaded to `Codecov` using the [codecov/codecov-action][] action.
@@ -135,7 +131,7 @@ If you would rather do it yourself, you should collect coverage files from all
 your jobs and combine them into one `.coverage` file before running
 `coverage report`, so that you get a combined score.
 
-##### Manually combining coverage
+#### Manually combining coverage
 
 If you are running in parallel, such as with `pytest-xdist`, you can set
 `run.parallel` to `true`, which will add a unique suffix to the coverage file(s)
@@ -199,7 +195,7 @@ def tests(session: nox.Session) -> None:
 :::
 ::::
 
-##### Merging and reporting
+#### Merging and reporting
 
 If you are running in multiple jobs, you should use upload/download artifacts so
 they are all available in a single combine job at the end. Each one should have
@@ -219,7 +215,7 @@ def coverage(session: nox.Session) -> None:
     session.run("coverage", "erase")
 ```
 
-##### Configuring Codecov and uploading coverage reports
+#### Configuring Codecov and uploading coverage reports
 
 Interestingly, `Codecov` does not require any initial configurations for your
 project, given that you have already signed up for the same using your GitHub
@@ -243,7 +239,7 @@ The lines above should be added after the step that runs your tests with the
 for all the optional options. You'll need to specify a `CODECOV_TOKEN` secret,
 as well.
 
-##### Using codecov.yml
+#### Using codecov.yml
 
 One can also configure `Codecov` and coverage reports passed to `Codecov` using
 `codecov.yml`. `codecov.yml` should be placed inside the `.github` folder, along

--- a/docs/pages/guides/docs.md
+++ b/docs/pages/guides/docs.md
@@ -1,8 +1,4 @@
----
-title: Writing documentation
----
-
-## Writing documentation
+# Writing documentation
 
 Documentation used to require learning reStructuredText (sometimes referred to
 as reST / rST), but today we have great choices for documentation in markdown,
@@ -45,7 +41,7 @@ is uncertain, and mkdocs-material will be minimally maintained until
 late 2026.
 :::
 
-### What to include
+## What to include
 
 Ideally, software documentation should include:
 
@@ -76,7 +72,7 @@ with render_cookie(backend="hatch", docs="mkdocs") as package:
 ]]] -->
 <!-- [[[end]]] -->
 
-### Hand-written docs
+## Hand-written docs
 
 Create `docs/` directory within your project (next to `src/`). From here, Sphinx
 and MkDocs diverge.
@@ -85,7 +81,7 @@ and MkDocs diverge.
 :::{tab-item} Sphinx
 :sync: sphinx
 
-#### pyproject.toml additions
+### pyproject.toml additions
 
 Setting a `docs` dependency group looks like this:
 
@@ -107,7 +103,7 @@ There is a sphinx-quickstart tool, but it creates unnecessary files (make/bat,
 we recommend a cross-platform noxfile instead), and uses rST instead of
 Markdown. Instead, this is our recommended starting point for `conf.py`:
 
-#### conf.py
+### conf.py
 
 <!-- [[[cog
 with code_fence("python"):
@@ -227,7 +223,7 @@ docstrings, even if the parameter isn't documented yet. Feel free to check
 [sphinx-autodoc-typehints](https://github.com/tox-dev/sphinx-autodoc-typehints)
 for more options.
 
-#### index.md
+### index.md
 
 Your `index.md` file can start out like this:
 
@@ -471,7 +467,7 @@ nav:
 :::
 ::::
 
-#### .readthedocs.yaml
+### .readthedocs.yaml
 
 In order to use <https://readthedocs.org> to build, host, and preview your
 documentation, you must have a `.readthedocs.yaml` file {rr}`RTD100` like
@@ -548,7 +544,7 @@ Python {rr}`RTD103`, several languages are supported here).
 Finally, we have a `commands` table which describes how to install our
 dependencies and build the documentation into the ReadTheDocs output directory.
 
-#### noxfile.py additions
+### noxfile.py additions
 
 Add a session to your `noxfile.py` to generate docs:
 
@@ -642,7 +638,7 @@ documentation on how to configure what directories are watched for changes,
 :::
 ::::
 
-### API docs
+## API docs
 
 ::::{tab-set}
 :::{tab-item} Sphinx
@@ -651,7 +647,7 @@ To build API docs, you need to add the following Nox job. It will rerun
 `sphinx-apidoc` to generate the sphinx autodoc pages for each of your public
 modules.
 
-#### noxfile.py additions
+### noxfile.py additions
 
 <!-- [[[cog
 with code_fence("python"):
@@ -721,7 +717,7 @@ module by being more specific, like `::: my_package.my_module.MyClass`.
 :::
 ::::
 
-### Notebooks in docs
+## Notebooks in docs
 
 ::::{tab-set}
 :::{tab-item} Sphinx

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -1,9 +1,8 @@
 ---
-title: "GHA: GitHub Actions intro"
 short_title: GitHub Actions introduction
 ---
 
-## GitHub Actions: Intro
+# GitHub Actions: Intro
 
 {rr}`GH100` The recommended CI for scientific Python projects is GitHub
 Actions (GHA), although its predecessor Azure is also in heavy usage, and other
@@ -25,7 +24,7 @@ with render_cookie() as package:
 ]]] -->
 <!-- [[[end]]] -->
 
-### Header
+## Header
 
 Your main CI workflow file should begin something like this:
 
@@ -47,7 +46,7 @@ you use a develop branch, you probably will want to include that. You can also
 specify specific branches for pull requests instead of running on all PRs (will
 run on PRs targeting those branches only).
 
-### Prek / Pre-commit
+## Prek / Pre-commit
 
 If you use [prek][] or [pre-commit][] in CI, you can run it directly in GitHub
 Actions. Prek is a faster Rust rewrite of pre-commit that supports most real
@@ -91,7 +90,7 @@ run a manual check, like check-manifest, then you can keep it but just use
 this one check. You can also use `needs: lint` in your other jobs to keep them
 from running if the lint check does not pass.
 
-### Unit tests
+## Unit tests
 
 Implementing unit tests is also easy. Since you should be following best
 practices listed in the previous sections, this becomes an almost directly
@@ -158,7 +157,7 @@ Note that while versioned images are available, like `ubuntu-24.04`, these are
 all rolling images; selecting a specific image will not make your CI completely
 static. And old versioned images are decommissioned.
 
-### Updating
+## Updating
 
 {rr}`GH200` {rr}`GH210` If you use non-default actions in your repository
 (you will see some in the following pages), then it's a good idea to keep them
@@ -190,9 +189,9 @@ which is both cleaner and sometimes required for dependent actions, like
 
 You can use this for other ecosystems too, including Python.
 
-### Common needs
+## Common needs
 
-#### Single OS steps
+### Single OS steps
 
 If you need to have a step run only on a specific OS, use an if on that step
 with `runner.os`:
@@ -204,7 +203,7 @@ if: runner.os != 'Windows' # also 'macOS' and 'Linux'
 Using `runner.os` is better than `matrix.<something>`. You also have an
 environment variable `$RUNNER_OS` as well. Single quotes are required here.
 
-#### Changing the environment in a step
+### Changing the environment in a step
 
 If you need to change environment variables for later steps, such combining with
 an if condition for only for one OS, then you add it to a special file:
@@ -215,7 +214,7 @@ an if condition for only for one OS, then you add it to a special file:
 
 Later steps will see this environment variable.
 
-#### Communicating between steps
+### Communicating between steps
 
 You can also directly communicate between steps, by setting `id:`'s. Some
 actions have outputs, and bash actions can manually write to output:
@@ -230,7 +229,7 @@ You can now refer to this step in a later step with
 using `${{ needs.<jobname>.outputs.something }}`. The `toJson()` function is
 useful for inputting JSON - you can even generate matrices dynamically this way!
 
-#### Pretty output
+### Pretty output
 
 You can write GitHub flavored markdown to `$GITHUB_STEP_SUMMARY`, and it will be
 shown on the summary page.
@@ -247,7 +246,7 @@ You can also do this
 which tell GitHub to look for certain patterns. Do keep in mind you can only see
 up to 10 matches per type per step, and a total of 50 matchers.
 
-#### Common useful actions
+### Common useful actions
 
 There are a variety of useful actions. There are GitHub supplied ones:
 
@@ -325,11 +324,11 @@ You can also run GitHub Actions locally:
 - [act](https://github.com/nektos/act): Run GitHub Actions in a docker image
   locally.
 
-### Advanced usage
+## Advanced usage
 
 These are some things you might need.
 
-#### Cancel existing runs
+### Cancel existing runs
 
 {rr}`GH102` If you add the following, you can ensure only one run per
 PR/branch happens at a time, cancelling the old run when a new one starts:
@@ -345,7 +344,7 @@ the "from" name for the PR. If you want, you can replace `github.ref` with
 `github.event.pull_request.number || github.sha`; this will still cancel on PR
 pushes but will build each commit on `main`.
 
-#### Pass job
+### Pass job
 
 If you want support GitHub's "merge when pass" feature, you should set up a pass
 job instead of listing every job you wand to require. Besides making it much
@@ -382,7 +381,7 @@ allowed to be skipped (`allowed-skips:`) too.
 Just set this `pass` job in your required checks for your main branch. Then
 you'll be able to use GitHub's auto merge functionality.
 
-#### Custom actions
+### Custom actions
 
 You can
 [write your own actions](https://docs.github.com/en/actions/creating-actions)
@@ -453,7 +452,7 @@ Examples of custom composite actions include:
   (This repo)
 :::
 
-#### Reusable workflows
+### Reusable workflows
 
 You can also make reusable workflows. One reason to do this is it allows you to
 use `needs` or communicate values between workflows. It's an easy way to make
@@ -470,7 +469,7 @@ If you add a `outputs:` table to the workflow call table, you can specify
 outputs for other workflows to read. See other options
 [in the docs](https://docs.github.com/en/actions/using-workflows/reusing-workflows).
 
-#### Conditional workflows
+### Conditional workflows
 
 Sometimes you have jobs that depend on certain files in our repository. Maybe
 you only want to run tests if code or tests files are changed, docs if
@@ -620,7 +619,7 @@ Some examples of repos using this method are:
   (this repo)
 :::
 
-#### GitHub pages
+### GitHub pages
 
 GitHub has finished moving their pages build infrastructure to Actions, and they
 [now provide](https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/)
@@ -702,7 +701,7 @@ for examples. Some other examples include:
 - [iris-hep.org](https://github.com/iris-hep/iris-hep.github.io/blob/master/.github/workflows/deploy.yml)
 :::
 
-#### Changelog generation
+### Changelog generation
 
 Not directly part of Actions, but also in `.github` is `.github/release.yml`,
 which lets you [configure the changelog generation][gh-changelog] button when

--- a/docs/pages/guides/gha_pure.md
+++ b/docs/pages/guides/gha_pure.md
@@ -1,9 +1,8 @@
 ---
-title: "GHA: Pure Python wheels"
 short_title: GitHub Actions for pure Python wheels
 ---
 
-## GitHub Actions: Pure Python wheels
+# GitHub Actions: Pure Python wheels
 
 We will cover binary wheels [on the next page][], but if you do not have a
 compiled extension, this is called a universal (pure Python) package, and the
@@ -29,7 +28,7 @@ reasons that a wheel is better than only providing an sdist:
 
 [on the next page]: pages/guides/gha-wheels
 
-### Job setup
+## Job setup
 
 ```yaml
 name: CD
@@ -56,7 +55,7 @@ releases(-only). You will also need to change the event filter below.
 You can merge the CI job and the CD job if you want. To do that, preferably with
 the name "CI/CD", you can just combine the two `on` dicts.
 
-### Distribution: Pure Python wheels
+## Distribution: Pure Python wheels
 
 ```yaml
 dist:

--- a/docs/pages/guides/gha_wheels.md
+++ b/docs/pages/guides/gha_wheels.md
@@ -1,15 +1,14 @@
 ---
-title: "GHA: Binary wheels"
 short_title: GitHub Actions for Binary Wheels
 ---
 
-## GitHub Actions: Binary wheels
+# GitHub Actions: Binary wheels
 
 Building binary wheels is a bit more involved, but can still be done effectively
 with GHA. This document will introduce [cibuildwheel][] for use in your project.
 We will focus on GHA below.
 
-### Header
+## Header
 
 Wheel building should only happen rarely, so you will want to limit it to
 releases, and maybe a rarely moving branch or other special tag (such as
@@ -39,7 +38,7 @@ Finally, if you change the workflow itself in a PR, then rebuild the wheels too.
 
 [workflow_dispatch]: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
 
-#### Useful suggestion
+### Useful suggestion
 
 Since these variables will be used by all jobs, you could make them available in
 your `pyproject.toml` file, so they can be used everywhere (even locally for
@@ -60,7 +59,7 @@ will cause the pip install to use the dependency-group(s) specified. The
 `test-command` will use pytest to run your tests. You can also set the build
 verbosity (`-v` in pip) if you want to.
 
-### Making an SDist
+## Making an SDist
 
 You probably should not forget about making an SDist! A simple job, like before,
 will work:
@@ -89,7 +88,7 @@ Instead of using `uv`, you can also run `pipx run build --sdist`, or install
 build via pip and use `python -m build --sdist`. You can also pin the version
 with `pipx run build==<version>`.
 
-### The core job (3 main OS's)
+## The core job (3 main OS's)
 
 The core of the work is down here:
 
@@ -153,7 +152,7 @@ set that in the `pyproject.toml` file instead.
 You can skip specifying the `build[uv]` build-frontend option and pre-installing
 `uv` on the runners, but it will be a slower.
 
-### Publishing
+## Publishing
 
 Trusted Publishing is more secure and recommended {rr}`GH105`:
 

--- a/docs/pages/guides/index.md
+++ b/docs/pages/guides/index.md
@@ -1,8 +1,4 @@
----
-title: Topical Guides
----
-
-## Topical Guides
+# Topical Guides
 
 The pages here are intended for developers who are making or maintaining a
 package and want to follow modern best practices in Python.

--- a/docs/pages/guides/mypy.md
+++ b/docs/pages/guides/mypy.md
@@ -1,10 +1,6 @@
----
-title: "Static type checking"
----
+# Static type checking
 
-## Static type checking
-
-### Basics
+## Basics
 
 The most exciting thing happening right now in Python development is static
 typing. Since Python 3.0, we've had function annotations, and since 3.6,
@@ -36,7 +32,7 @@ Your tests cannot test every possible branch, every line of code. MyPy can
 runs rarely, that requires remote resources, that is slow, etc. All those can be
 checked by MyPy. It also keeps you (too?) truthful in your types.
 
-#### Adding types
+### Adding types
 
 There are three ways to add types.
 
@@ -60,7 +56,7 @@ it for parameters and returns from functions. When running MyPy, you can use
 print statement but at type-checking time, or `reveal_locals()` to see all local
 types.
 
-#### Configuration
+### Configuration
 
 By default, MyPy does as little as possible, so that you can add it iteratively
 to a code base. By default:
@@ -84,9 +80,9 @@ type hints for (mostly) the standard library.
 Third party libraries that are typed sometimes forget this last step, by the
 way!
 
-### Features
+## Features
 
-#### Type narrowing
+### Type narrowing
 
 One of the key features of type checking is type narrowing. The type checker
 monitors the types of a variable, and "narrows" it when something restricts it.
@@ -116,7 +112,7 @@ reveal_type(x)
 This will print `A` because you removed B via the type narrowing using the
 `assert`.
 
-#### Protocols
+### Protocols
 
 One of the best features of MyPy is support for structural subtyping via
 Protocols - formalized duck-typing, basically. This allows cross library
@@ -168,7 +164,7 @@ There are lots of built-in Protocols, most of which pre-date typing and are
 available in an Abstract Base Class form. Most of them check for one or more
 special methods, like `Iterable`, `Iterator`, etc.
 
-#### Other features
+### Other features
 
 Static typing has some great features worth checking out:
 
@@ -180,9 +176,9 @@ Static typing has some great features worth checking out:
 - MyPy validates with the Python version you ask for, regardless of what version
   you are actually running.
 
-### Complete example
+## Complete example
 
-#### Runtime compatible types
+### Runtime compatible types
 
 Here's the classic syntax, which you need to use if you want to access the type
 annotations at runtime and you need to support Python < 3.10:
@@ -207,7 +203,7 @@ def g(x: Union[str, int]) -> None:
     # Calling x.lower() is invalid here!
 ```
 
-#### Types as strings
+### Types as strings
 
 If you don't access the types at runtime, or if you use Python 3.10+ only, then
 you can use a much nicer syntax. The `annotations` future feature causes the
@@ -237,11 +233,11 @@ annotations at runtime.
 You can use the above in earlier Python versions if you use strings manually,
 with the same caveats.
 
-### Tips for good types
+## Tips for good types
 
 These are some guidelines to help you in writing good type hints.
 
-#### Loose vs. specific types
+### Loose vs. specific types
 
 When you have a function, you should take as generic a type as possible, and
 return as specific a type as possible. For example:
@@ -289,7 +285,7 @@ Also note that the best place to get these in modern Python is
 `collections.abc`, but if you need to subscript them at runtime, you'll need
 Python 3.9+ or the versions in `typing`.
 
-### Final words
+## Final words
 
 When run alongside a good linter like flake8, this can catch a huge number of
 issues before tests or they are discovered in the wild! It also prompts _better

--- a/docs/pages/guides/packaging_classic.md
+++ b/docs/pages/guides/packaging_classic.md
@@ -1,8 +1,4 @@
----
-title: Classic packaging
----
-
-## Classic packaging
+# Classic packaging
 
 The libraries in the scientific Python ecosytem have a variety of different
 packaging styles, but this document is intended to outline a recommended style
@@ -36,7 +32,7 @@ include a `setup.py`, and all alternate packing systems produce "normal"
 wheels.
 :::
 
-### Package structure (medium priority)
+## Package structure (medium priority)
 
 All packages _should_ have a `src` folder, with the package code residing inside
 it, such as `src/<package>/`. This may seem like extra hassle; after all, you
@@ -46,7 +42,7 @@ common bugs, such as running `pytest` and getting the local version instead of
 the installed version - this obviously tends to break if you build parts of the
 library or if you access package metadata.
 
-### PEP 517/518 support (high priority)
+## PEP 517/518 support (high priority)
 
 Packages should provide a `pyproject.toml` file that _at least_ looks like this:
 
@@ -82,7 +78,7 @@ compliant SDists, as well).
 {rr}`PP003` Note that `"wheel"` is never required; it was injected
 automatically by setuptools in older versions, and is no longer used at all.
 
-#### Special additions: NumPy
+### Special additions: NumPy
 
 You may want to build against NumPy (mostly for Cython packages, pybind11 does
 not need to access the NumPy headers). This is the recommendation for scientific
@@ -116,11 +112,11 @@ NumPy 2.0. Now you add:
 sure you build with NumPy 1.25+ (or 2.0+ when it comes out).
 :::
 
-### Versioning (medium/high priority)
+## Versioning (medium/high priority)
 
 Scientific Python packages should use one of the following systems:
 
-#### Git tags: official PyPA method
+### Git tags: official PyPA method
 
 One more section is very useful in your `pyproject.toml` file:
 
@@ -223,7 +219,7 @@ This will allow git archives (including the ones generated from GitHub) to also
 support versioning. This will only work with `setuptools_scm>=7` (though adding
 the files won't hurt older versions).
 
-#### Classic in-source versioning
+### Classic in-source versioning
 
 Recent versions of `setuptools` have improved in-source versioning. If you have
 a simple file that includes a line with a simple PEP 440 style version, like
@@ -244,7 +240,7 @@ requirements only, this will fail.
 Flit will always look for `package.__version__`, and so will always import your
 package; you just have to deal with that if you use Flit.
 
-### Setup configuration (medium priority)
+## Setup configuration (medium priority)
 
 You should put as much as possible in your `setup.cfg`, and leave `setup.py` for
 _only_ parts that need custom logic or binary building. This keeps your
@@ -354,7 +350,7 @@ junit_family = "xunit2"
 testpaths = ["tests"]
 ```
 
-### Extras (low/medium priority)
+## Extras (low/medium priority)
 
 It is recommended to use extras instead of or in addition to making requirement
 files. These extras a) correctly interact with install requires and other
@@ -398,7 +394,7 @@ Self dependencies can be placed in `setup.cfg` using the name of the package,
 such as `dev = package[test,examples]`, but this requires Pip 21.2 or newer. We
 recommend providing at least `test`, `docs`, and `dev`.
 
-### Including/excluding files in the SDist
+## Including/excluding files in the SDist
 
 Python packaging goes through a 3-stage procedure if you have the above
 recommended `pyproject.toml` file. If you type `pip install .`, then
@@ -434,7 +430,7 @@ include LICENSE README.md pyproject.toml setup.py setup.cfg
 global-exclude __pycache__ *.py[cod] .venv
 ```
 
-### Command line
+## Command line
 
 If you want to ship an "app" that a user can run from the command line, you need
 to add a `console_scripts` entry point. The form is:

--- a/docs/pages/guides/packaging_compiled.md
+++ b/docs/pages/guides/packaging_compiled.md
@@ -1,6 +1,4 @@
----
-title: Compiled packaging
----
+# Packaging Compiled Projects
 
 <!-- [[[cog
 from cog_helpers import code_fence, render_cookie, TOMLMatcher
@@ -25,8 +23,6 @@ Once you've done this at least once, feel free to use
 [our cookiecutter/copier template](https://github.com/scientific-python/cookie),
 or `uv init` to get started quickly on new packages!
 :::
-
-## Packaging Compiled Projects
 
 There are a variety of ways to package compiled projects. In the past, the only
 way to do it was to use setuptools/distutils, which required using lots of
@@ -63,7 +59,7 @@ elegant as Meson, there are a lot of historical examples of poorly written
 CMake.
 :::
 
-### pyproject.toml: build-system
+## pyproject.toml: build-system
 
 {rr}`PY001` Packages must have a `pyproject.toml` file {rr}`PP001` that
 selects the backend:
@@ -119,7 +115,7 @@ build-backend = "maturin"
 ```{include} ../../_partials/pyproject.md
 ```
 
-### Tool section in pyproject.toml
+## Tool section in pyproject.toml
 
 These tools all read the project table. They also have extra configuration
 options in `tool.*` settings.
@@ -167,7 +163,7 @@ configuration here to follow the convention of the other tools here.
 :::
 ::::
 
-### Backend specific files
+## Backend specific files
 
 ::::{tab-set}
 :::{tab-item} Scikit-build-core
@@ -272,7 +268,7 @@ features = ["extension-module", "abi3-py310"]
 :::
 ::::
 
-### Example compiled file
+## Example compiled file
 
 This example will make a `_core` extension inside your package; this pattern
 allows you to easily provide both Python files and compiled extensions, and
@@ -404,32 +400,32 @@ mod _core {
 :::
 ::::
 
-### Package structure
+## Package structure
 
 The recommendation (followed above) is to have source code in `/src`, and the
 Python package files in `/src/<package>`. The compiled files also can go in
 `/src`.
 
-### Versioning
+## Versioning
 
 Check the documentation for the tools above to see what forms of dynamic
 versioning the tool supports.
 
-### Including/excluding files in the SDist
+## Including/excluding files in the SDist
 
 Each tool uses a different mechanism to include or remove files from the SDist,
 though the defaults are reasonable.
 
-### Distributing
+## Distributing
 
 Unlike pure Python, you'll need to build redistributable wheels for each
 platform and supported Python version if you want to avoid compilation on the
 user's system using cibuildwheel. See [the CI page on wheels][gha_wheels] for a
 suggested workflow.
 
-### Special considerations
+## Special considerations
 
-#### NumPy
+### NumPy
 
 Modern versions of NumPy (1.25+) allow you to target older versions when
 building, which is _highly_ recommended, and this became required in NumPy 2.0.

--- a/docs/pages/guides/packaging_simple.md
+++ b/docs/pages/guides/packaging_simple.md
@@ -1,14 +1,10 @@
----
-title: Simple packaging
----
+# Simple packaging
 
 :::{tip} Quick start
 Once you've done this at least once, feel free to use
 [our cookiecutter/copier template](https://github.com/scientific-python/cookie),
 or `uv init` to get started quickly on new packages!
 :::
-
-## Simple packaging
 
 Python packages can now use a modern build system instead of the classic but
 verbose setuptools and `setup.py`. The one you select doesn't really matter that
@@ -37,7 +33,7 @@ from VCS. If you don't have an existing preference, hatchling is an excellent
 choice, balancing speed, configurability, and extendability.
 :::
 
-### pyproject.toml: build-system
+## pyproject.toml: build-system
 
 {rr}`PY001` Packages must have a `pyproject.toml` file {rr}`PP001` that
 selects the backend:
@@ -98,7 +94,7 @@ should not put an upper cap on it {rr}`PP004`, as this field is used to
 back-solve for old package versions that pass this check, allowing you to safely
 drop Python versions.
 
-### Package structure
+## Package structure
 
 All packages _should_ have a `src` folder, with the package code residing inside
 it, such as `src/<package>/`. This may seem like extra hassle; after all, you
@@ -119,7 +115,7 @@ You should have a `README` {rr}`PY002` and a `LICENSE` {rr}`PY003` file.
 You should have a `docs/` folder {rr}`PY004`. You should have a `/tests`
 folder {rr}`PY005` (recommended) and/or a `src/<package>/tests` folder.
 
-### Versioning
+## Versioning
 
 You can specify the version manually (as shown in the example), but the backends
 usually provide some automatic features to help you avoid this. Flit will pull
@@ -174,7 +170,7 @@ This will allow git archives (including the ones generated from GitHub) to also
 support versioning.
 :::
 
-### Including/excluding files in the SDist
+## Including/excluding files in the SDist
 
 This is tool specific.
 

--- a/docs/pages/guides/pytest.md
+++ b/docs/pages/guides/pytest.md
@@ -1,8 +1,4 @@
----
-title: "Testing with pytest"
----
-
-## Testing with pytest
+# Testing with pytest
 
 Tests are crucial to writing reliable software. A good test suite allows you to:
 
@@ -33,7 +29,7 @@ testing too. So just use `pytest`. All major packages use it too, including
 just extend it.
 :::
 
-### Basic test structure
+## Basic test structure
 
 You should make a folder called "tests" in your repository (probably alongside
 your `src` or module folder, but rarely they are placed inside the module
@@ -55,7 +51,7 @@ This looks simple, but it is doing several things:
   happens. If it fails, you will get a clear, detailed report on what each value
   was.
 
-#### Configuring pytest
+### Configuring pytest
 
 pytest supports configuration in `pytest.ini`, `setup.cfg`, or, since version 6,
 `pyproject.toml` {rr}`PP301`, or, since version 9, `pytest.toml` or
@@ -139,7 +135,7 @@ becoming errors using the syntax
 tends to be `default` (show the first time) or `ignore` (never show). The regex
 matches at the beginning of the error unless you prefix it with `.*`.
 
-#### Running pytest
+### Running pytest
 
 You can run pytest directly with `pytest` or `python -m pytest`. You can
 optionally give a directory or file to run on. You can also select just some
@@ -156,13 +152,13 @@ start out in your debugger at the beginning of the last failed test with
 `--trace --lf`. [See the docs](https://docs.pytest.org/en/stable/usage.html) for
 more running tips.
 
-### Guidelines for writing good tests
+## Guidelines for writing good tests
 
 Time spent learning all the powerful tools pytest has to offer will be well
 spent! You can make your tests more granular, mock things that aren't available
 (or are slow to run), parametrize, and much more.
 
-#### Tests should be easy
+### Tests should be easy
 
 Always use pytest. The built-in unittest is _very_ verbose; the simpler the
 writing of tests, the more tests you will write!
@@ -205,7 +201,7 @@ This natively works with NumPy arrays, too! Always prefer
 `array1 == approx(array2)` over the functions in the `numpy.testing` module if
 you can, it is simpler and the reporting is better.
 
-#### Tests should test for failures too
+### Tests should test for failures too
 
 You should make sure that expected errors are thrown:
 
@@ -221,7 +217,7 @@ def test_raises():
 You can check for warnings as well, with `pytest.warns` or
 `pytest.deprecated_call`.
 
-#### Tests should stay easy when scaling out
+### Tests should stay easy when scaling out
 
 pytest [uses fixtures](https://docs.pytest.org/en/stable/fixture.html) to
 represent complex ideas, like setup/teardown, temporary resources, or
@@ -284,7 +280,7 @@ conftest) will run three times, and each time will identify as a different
 `platform.system()`! Leave `autouse` off, and it becomes opt-in; adding
 `platform_system` to the list of arguments will opt in.
 
-#### Tests should be organized
+### Tests should be organized
 
 You can use `pytest.mark.*` to
 [mark](https://docs.pytest.org/en/stable/mark.html) tests, so you can easily
@@ -316,7 +312,7 @@ Many pytest plugins support new marks too, like `pytest-parametrize`. You can
 also use custom marks to enable/disable groups of tests, or to pass data into
 fixtures.
 
-#### Tests should test the installed version, not the local version
+### Tests should test the installed version, not the local version
 
 Your tests should run against an _installed_ version of your code. Testing
 against the _local_ version might work while the installed version does not (due
@@ -327,7 +323,7 @@ directories and `pytest` does not. Also, there may come a time when someone
 a build system, and if you are unable to test against an installed version, you
 won't be able to run your tests! (It happens more than you might think).
 
-#### Mock expensive or tricky calls
+### Mock expensive or tricky calls
 
 If you have to call something that is expensive or hard to call, it is often
 better to mock it. To isolate parts of your own code for "unit" testing, mocking

--- a/docs/pages/guides/repo_review.md
+++ b/docs/pages/guides/repo_review.md
@@ -1,8 +1,4 @@
----
-title: Repo-Review
----
-
-## Repo-Review
+# Repo-Review
 
 You can check the style of a GitHub repository below. Enter any repository, such
 as `scikit-hep/hist`, and the branch you want to check, such as `main` (it must

--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -1,11 +1,10 @@
 ---
-title: Style & static checks
 short_title: Style and static checks
 ---
 
-## Style and static checks
+# Style and static checks
 
-### Pre-commit
+## Pre-commit
 
 {rr}`PY006` Scientific Python projects often use [pre-commit][] (or [prek][])
 to check code style. The original, `pre-commit`, has support for more languages,
@@ -117,7 +116,7 @@ updates:
       default-days: 7
 ```
 
-### Format
+## Format
 
 {rr}`PC110` [Black](https://black.readthedocs.io/en/latest/) is a popular
 auto-formatter from the Python Software Foundation. One of the main features of
@@ -222,7 +221,7 @@ markdown and restructured text. Note that because black is in
 
 :::
 
-### Ruff
+## Ruff
 
 {rr}`PC190` [Ruff][] [(docs)][ruff docs] is a Python code linter and
 autofixer that replaces many other tools in the ecosystem with a ultra-fast
@@ -437,7 +436,7 @@ release.
 
 ::::{dropdown} Separate tools that Ruff replaces
 
-#### PyCln
+### PyCln
 
 [PyCln][] will clean up your imports if you have any that are not needed. There
 is a Flake8 check for this, but it's usually nicer to automatically do the
@@ -453,7 +452,7 @@ use the manual stage, it's opt-in instead of automatic.
       stages: [manual]
 ```
 
-#### Flake8
+### Flake8
 
 [Flake8][] can check a collection of good practices for you, ranging from simple
 style to things that might confuse or detract users, such as unused imports,
@@ -528,7 +527,7 @@ per-file-ignores =
 
 :::
 
-#### YesQA
+### YesQA
 
 Over time, you can end up with extra "noqa" comments that are no longer needed.
 This is a flake8 helper that removes those comments when they are no longer
@@ -545,7 +544,7 @@ You need to have the same extra dependencies as flake8. In YAML, you can save
 the list given to yesqa and repeat it in flake8 using `&flake8-dependencies` and
 `*flake8-dependencies` after the colon.
 
-#### isort
+### isort
 
 You can have your imports sorted automatically by [isort][]. This will sort your
 imports, and is black compatible. One reason to have sorted imports is to reduce
@@ -571,7 +570,7 @@ In order to use it, you need to add some configuration. You can add it to
 profile = "black"
 ```
 
-#### PyUpgrade
+### PyUpgrade
 
 Another useful tool is [PyUpgrade][], which monitors your codebase for "old"
 style syntax. Most useful to keep Python 2 outdated constructs out, it can even
@@ -602,7 +601,7 @@ will clean up your annotations to 3.7+ style, too!
 :::
 ::::
 
-### Type checking
+## Type checking
 
 {rr}`PC140` One of the most exciting advancements in Python in the last 10
 years has been static type hints. Scientific Python projects vary in the degree
@@ -677,13 +676,13 @@ errors in your typing.
 
 [mypy page]: pages/guides/mypy
 
-### Setuptools specific checks
+## Setuptools specific checks
 
 If you use setuptools, these checks are useful:
 
 ::::{dropdown} Setuptools-only checks
 
-#### Check-Manifest (setuptools only)
+### Check-Manifest (setuptools only)
 
 [Check-manifest](https://pypi.org/project/check-manifest/) is a fantastic,
 highly recommended tool that verifies you have working SDists. You can install
@@ -727,7 +726,7 @@ run all checks:
 
 :::
 
-#### Setup.cfg format (setuptools only)
+### Setup.cfg format (setuptools only)
 
 There is a tool that keeps your `setup.cfg` organized, and makes sure that
 important parts (like Python classifiers) are in sync. This tool,
@@ -744,7 +743,7 @@ important parts (like Python classifiers) are in sync. This tool,
 Make sure you list the highest version of Python you are testing with here.
 ::::
 
-### Spelling
+## Spelling
 
 {rr}`PC160` You can and should check for spelling errors in your code too. If
 you want to add this, you can use a code-ready spell checker for common spelling
@@ -821,7 +820,7 @@ such as the one below:
       exclude: .pre-commit-config.yaml
 ```
 
-### PyGrep hooks
+## PyGrep hooks
 
 {rr}`PC170` This is a repository with a
 [collection of pre-commit extra hooks](https://github.com/pre-commit/pygrep-hooks)
@@ -861,7 +860,7 @@ also:
 
 :::
 
-### Clang-format (C++ only)
+## Clang-format (C++ only)
 
 If you have C++ code, you should have a `.clang-format` file and use the
 following pre-commit config:
@@ -878,7 +877,7 @@ This will use 1-2 MB binary wheels from PyPI on all common platforms. You can
 generated such a file using
 `pipx run clang-format -style=llvm -dump-config > .clang-format`.
 
-### Shellcheck (shell scripts only)
+## Shellcheck (shell scripts only)
 
 If you have shell scripts, you can protect against common mistakes using
 [shellcheck](https://github.com/koalaman/shellcheck).
@@ -890,7 +889,7 @@ If you have shell scripts, you can protect against common mistakes using
     - id: shellcheck
 ```
 
-### Prettier
+## Prettier
 
 {rr}`PC180` The [prettier](https://prettier.io) tool can format a large
 number of different file types. An example of usage:
@@ -919,7 +918,7 @@ be set to `"never"` or `"always"` to have prettier reflow text. You can turn off
 prettier for blocks with
 [comments depending on language](https://prettier.io/docs/en/ignore.html).
 
-### Schema validation
+## Schema validation
 
 There are two tools, both based on JSON Schema, that you can use to validate
 various configuration files. The first, [validate-pyproject][], validates your
@@ -952,7 +951,7 @@ schemas, and you can load them via URL. It work on JSON, YAML, and TOML.
     - id: check-readthedocs
 ```
 
-### Pylint (noisy)
+## Pylint (noisy)
 
 Pylint is very opinionated, with a high signal-to-noise ratio. However, by
 limiting the default checks or by starting off a new project using them, you can
@@ -991,26 +990,26 @@ And you can add this to your GitHub Actions using
 `run: pipx run nox -s pylint -- --output-format=github`. You can replace
 `<your package>` with the module name.
 
-### Jupyter notebook support
+## Jupyter notebook support
 
-#### Ruff
+### Ruff
 
 Ruff natively supports notebooks. You no longer need to enable it, it's on by
 default with Ruff 0.6+. If you want to control rules based on being notebooks,
 you can just match with `**.ipynb` like any other file.
 
-#### Black
+### Black
 
 For Black, just make sure you use the `id: black-jupyter` hook instead of
 `id: black`; that will also include notebooks.
 
-#### NBQA
+### NBQA
 
 You can adapt other tools to notebooks using
 [nbQA](https://github.com/nbQA-dev/nbQA). However, check to see if the tool
 natively supports notebooks first, several of them do now.
 
-#### Stripping output
+### Stripping output
 
 You also might like the following hook, which cleans Jupyter outputs:
 

--- a/docs/pages/guides/tasks.md
+++ b/docs/pages/guides/tasks.md
@@ -1,8 +1,4 @@
----
-title: Task runners
----
-
-## Task runners
+# Task runners
 
 <!-- [[[cog
 from cog_helpers import  code_fence, render_cookie, PyMatcher
@@ -55,9 +51,9 @@ be best left to just specialized tasks.
 [rake]: https://ruby.github.io/rake/
 [make]: https://www.gnu.org/software/make/
 
-### Nox
+## Nox
 
-#### Installing
+### Installing
 
 Installing nox should be handled like any other Python _application_. You should
 either use a good package manager, like brew on macOS, or you should use pipx;
@@ -83,7 +79,7 @@ customize the versions of Python prepared for you, then use input like this:
     python-versions: "3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t, pypy-3.11"
 ```
 
-#### Introduction
+### Introduction
 
 Nox is a tool for running tasks, called "sessions", inside temporary virtual
 environments. It is configured through Python and is designed to resemble
@@ -125,7 +121,7 @@ You can see all defined sessions (along with the docstrings) using:
 nox -l
 ```
 
-#### Parametrizing
+### Parametrizing
 
 You can parametrize sessions. either on Python or on any other item.
 
@@ -155,14 +151,14 @@ docker run --rm -itv $PWD:/src -w /src quay.io/pypa/manylinux_2_28_x86_64:latest
 Another container you can use is `thekevjames/nox:latest`; this has nox
 pre-installed (no pipx) and Python 2.7 and 3.5 as well.
 
-#### Useful sessions
+### Useful sessions
 
 Things like bumping the versions can be made sessions - since nox handles the
 environment for you, you can use any Python dependencies you like, and not have
 to worry about installing anything. Here are some commonly useful sessions that
 will likely look similar across different projects:
 
-##### Lint
+#### Lint
 
 Ideally, all developers should be using pre-commit or prek directly, but this
 helps new users.
@@ -186,7 +182,7 @@ def lint(session: nox.Session) -> None:
 <!-- rumdl-enable MD013 -->
 <!-- [[[end]]] -->
 
-##### Tests
+#### Tests
 
 <!-- [[[cog
 with code_fence("python"):
@@ -206,7 +202,7 @@ def tests(session: nox.Session) -> None:
 <!-- rumdl-enable MD013 -->
 <!-- [[[end]]] -->
 
-##### Docs
+#### Docs
 
 <!-- [[[cog
 with code_fence("python"):
@@ -257,7 +253,7 @@ nox -s docs -- --serve
 Notice that we set `default=False` so that docs are not built every time nox is
 run without arguments. {rr}`NOX103`
 
-##### Build (pure Python)
+#### Build (pure Python)
 
 For pure Python packages, this could be useful:
 
@@ -297,7 +293,7 @@ def build(session: nox.Session) -> None:
 
 (Removing the build directory is helpful for setuptools)
 
-#### Faster with uv
+### Faster with uv
 
 The [uv](https://github.com/astral-sh/uv) project is a Rust reimplementation of
 pip, pip-tools, and venv that is very, very fast. You can tell nox to use `uv`
@@ -322,7 +318,7 @@ interact with uv, nox might be getting uv from it's environment instead of the
 system environment, so you can install `uv` if `shutil.which("uv")` returns
 `None`. You should also set a minimum version of nox. {rr}`NOX101`
 
-#### Running without nox or requiring dependencies
+### Running without nox or requiring dependencies
 
 Nox also allows you to use the script block, both for running with runners (like
 `uv run` and `pipx run`), and for specifying dependencies to install or a
@@ -354,7 +350,7 @@ run directly if it is made executable. You can put any runner here; uv is shown.
 You also need a main block {rr}`NOX203` to allow nox to be run when this file
 is executed directly.
 
-#### Examples
+### Examples
 
 A standard
 [powered by nox](https://github.com/scikit-hep/hist/blob/main/noxfile.py)

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -1,10 +1,10 @@
 ---
-title: Home
+short_title: Home
 site:
   hide_outline: true
 ---
 
-## Scientific Python Library Development Guide
+# Scientific Python Library Development Guide
 
 This guide is maintained by the scientific Python community for the benefit of
 fellow scientists and research software engineers.
@@ -44,7 +44,7 @@ to use successfully and easier to maintain over time.
 tasks and can be tricky to get exactly right, such as including data files with
 Python packages.
 
-### Related Resources
+## Related Resources
 
 This guide does _not_ cover the basics of Python itself or the scientific Python
 libraries; it focuses on making or maintaining a package. We recommend the

--- a/docs/pages/patterns/backports.md
+++ b/docs/pages/patterns/backports.md
@@ -1,8 +1,4 @@
----
-title: Backports
----
-
-## Backports
+# Backports
 
 A lot of additions to Python come with backports for older Pythons. Here are a
 few tips for using backports:
@@ -18,7 +14,7 @@ few tips for using backports:
 
 The rules for using a backport are as follows:
 
-### Conditional requirement
+## Conditional requirement
 
 Add it conditionally to your requirements. This looks something like this:
 
@@ -31,7 +27,7 @@ dependencies = [
 ]
 ```
 
-### Conditional usage
+## Conditional usage
 
 Always use the backport conditionally, with the following idiom:
 
@@ -61,7 +57,7 @@ advantages:
   important fixes landed in 3.10.
 - It matches your conditional requirements.
 
-### Placement in a file
+## Placement in a file
 
 Placing all conditional backports in a common location is a nice practice.
 Here's a suggestion: Place all imports inside `src/<package>/_compat`, in the
@@ -97,7 +93,7 @@ Ruff needs to know if you are re-exporting `typing`/`typing_extensions`, so make
 sure you add `typing-modules = ["<package>._compat.typing"]` to Ruff's config in
 `pyproject.toml`.
 
-### Typing dependencies
+## Typing dependencies
 
 While it's not usually necessary, you can avoid the `typing_extensions` backport
 at runtime by protecting the imports with `typing.TYPE_CHECKING`.
@@ -106,7 +102,7 @@ there's a good chance one of your dependencies is already pulling it. But if you
 really, really want to keep dependencies minimal, you can do this in your typing
 backport re-export file.
 
-### Common backport packages
+## Common backport packages
 
 - `typing_extensions`: New features in `typing` are added here first.
 - `importlib_metadata`: Added as `importlib.metadata` in 3.8, important updates

--- a/docs/pages/patterns/data_files.md
+++ b/docs/pages/patterns/data_files.md
@@ -1,8 +1,4 @@
----
-title: Including data files
----
-
-## Including data files
+# Including data files
 
 In this section you will:
 
@@ -10,7 +6,7 @@ In this section you will:
 - Learn some alternative approaches.
 - Learn how to include small data files in your package.
 
-### Consider Alternatives
+## Consider Alternatives
 
 **Never include large binary files in your Python package or git repository.**
 Once committed, the file lives in git history forever. Git will become sluggish,
@@ -42,7 +38,7 @@ If the file in question is a text file and not very large (\< 100 kB) than it's
 reasonable to just bundle it with the package. If not, see the recommendation at
 the end.
 
-### How to Package Data Files
+## How to Package Data Files
 
 What's the problem we are solving here? If your Python program needs to access a
 data file, the naïve solution is just to hard-code the path to that file.
@@ -142,7 +138,7 @@ with resources.as_file(ref) as path:
         spacings_txt = f.read()
 ```
 
-#### Using the init
+### Using the init
 
 Instead of having an empty init, you can instead move the `files(...)` into the
 `__init__.py`. That would look like this:
@@ -158,7 +154,7 @@ LaB6 = files / "LaB6.txt"
 Now, a user can simply import and use `package.peak_spacings.LaB6` and such
 directly.
 
-### Downloading larger files on demand
+## Downloading larger files on demand
 
 A common use case is that a project may have example notebooks or demo scripts
 which require data not distributed with the project itself. One approach in

--- a/docs/pages/patterns/exports.md
+++ b/docs/pages/patterns/exports.md
@@ -1,8 +1,4 @@
----
-title: Exports
----
-
-## Exports
+# Exports
 
 What objects in a module can you use? One common convention is that starting a
 name with a single underscore makes it "private" (though really "hidden" might
@@ -25,7 +21,7 @@ can cause surprising problems in some cases, though, due to Python's late
 binding. It's also easy to forget to delete something like an import, due to the
 fact the `del` statements are at the end of the module, far away from the usage.
 
-### Setting all
+## Setting all
 
 The solution to this is the `__all__` attribute. This is a public declaration of
 your exported API. It looks like this:

--- a/docs/pages/patterns/index.md
+++ b/docs/pages/patterns/index.md
@@ -1,8 +1,4 @@
----
-title: Patterns
----
-
-## Patterns
+# Patterns
 
 Patterns is a collection of common patterns in scientific software that are
 worth learning. These try to highlight best practices for specific situations,

--- a/docs/pages/principles/design.md
+++ b/docs/pages/principles/design.md
@@ -1,10 +1,6 @@
----
-title: Design recommendations
----
+# Design recommendations
 
-## Design recommendations
-
-### Keep I/O separate
+## Keep I/O separate
 
 One of the biggest impediments to reuse of scientific code is when I/O
 code---assuming certain file locations, names, formats, or layouts---is
@@ -16,7 +12,7 @@ The valuable scientific logic should be encoded in functions that take in
 standard data types and return standard data types. This makes them easier to
 test, maintain when data formats change, or reuse for unforeseen applications.
 
-### Duck typing is a good idea
+## Duck typing is a good idea
 
 [Duck typing][] treats objects based on what they can _do_, not based on what
 type they _are_. "If it walks like a duck and it quacks like a duck, then it
@@ -31,7 +27,7 @@ provides the right methods (interfaces). Where possible, avoid `isinstance`
 checks in your code, and try to make your functions work on the broadest
 possible range of input types.
 
-### Consider: can this just be a function?
+## Consider: can this just be a function?
 
 Not everything needs to be object-oriented. Object-oriented design needs to
 follow the same principles as other code, like modularity, and be well tested.
@@ -51,7 +47,7 @@ _seem_ to lend themselves to object-oriented programming are much more simply
 handled using functions. The biggest danger of reaching for OO design when it's
 not needed is the following: changing states.
 
-### Avoid changing state
+## Avoid changing state
 
 It is often tempting to invent a custom class to express a workflow, along these
 lines.
@@ -95,7 +91,7 @@ state that makes subsets of available operations (i.e. methods) invalid. Note
 that tab completion in this case would show exactly the allowed set of
 operations each time.
 
-### Consider: do I really want a custom class?
+## Consider: do I really want a custom class?
 
 Using built-in Python types (`int`, `float`, `str`) and standard scientific
 Python types like NumPy array and Pandas DataFrame makes code interoperable. It
@@ -124,7 +120,7 @@ class Data:
     count: int
 ```
 
-### Static typing is verbose, but makes code more readable
+## Static typing is verbose, but makes code more readable
 
 Code with static types has a lot of extra characters, but it provides more
 _information_ to the reader; `timestamp: int` or `timestamp: float` provides
@@ -142,7 +138,7 @@ When using static typing, duck typing is expressed via Protocols. These should
 be strongly preferred over older solutions like inheritance or ABCs if possible,
 as they trade a little extra code to remove dependencies between objects.
 
-### Permissiveness isn't always convenient
+## Permissiveness isn't always convenient
 
 Overly permissive code can lead to very confusing bugs. If you need a flexible
 user-facing interface that tries to "do the right thing" by guessing what the
@@ -162,20 +158,20 @@ what to do about it. _Application_ code (e.g. GUIs) should catch and handle
 errors to avoid crashing, but _library_ code should generally raise errors
 unless it is sure how the user or the caller wants to handle them.
 
-### Write useful error messages
+## Write useful error messages
 
 Be specific. Include what the wrong value was, what was wrong with it, and
 perhaps how it might be fixed. For example, if the code fails to locate a file
 it needs, it should say what it was looking for and where it looked.
 
-### Write for readability
+## Write for readability
 
 Unless you are writing a script that you plan to delete tomorrow or next week,
 your code will probably be read many more times than it is written. And today's
 "temporary solution" often becomes tomorrow's critical code. Therefore, optimize
 for clarity over brevity, using descriptive and consistent names.
 
-### Complexity is always conserved
+## Complexity is always conserved
 
 Complexity is always conserved and is strictly greater than the system the code
 is modeling. Attempts to hide complexity from the user frequently backfire.

--- a/docs/pages/principles/index.md
+++ b/docs/pages/principles/index.md
@@ -1,8 +1,4 @@
----
-title: Principles
----
-
-## Principles
+# Principles
 
 These pages are focused on designing good software, with a focus on end-user
 research code. [Process recommendations][] discusses the process of writing

--- a/docs/pages/principles/process.md
+++ b/docs/pages/principles/process.md
@@ -1,10 +1,6 @@
----
-title: Process recommendations
----
+# Process recommendations
 
-## Process recommendations
-
-### Collaborate
+## Collaborate
 
 Software developed by several people is preferable to software developed by one.
 By adopting the conventions and tooling used by many other scientific software
@@ -27,7 +23,7 @@ If you can bring together contributors with diverse scientific backgrounds, it
 becomes easier to identify functionality that should be generalized for reuse by
 different fields.
 
-### Don't be afraid to refactor
+## Don't be afraid to refactor
 
 No code is ever right the first (or second) time.
 
@@ -35,7 +31,7 @@ Refactoring the code once you understand the problem and the design trade-offs
 more fully helps keep the code maintainable. Version control, tests, and linting
 are your safety net, empowering you to make changes with confidence.
 
-### Prefer "wide" over "deep"
+## Prefer "wide" over "deep"
 
 It should be possible to reuse pieces of software in a way not anticipated by
 the original author. That is, branching out from the initial use case should

--- a/docs/pages/principles/testing.md
+++ b/docs/pages/principles/testing.md
@@ -1,8 +1,4 @@
----
-title: Testing recommendations
----
-
-## Testing recommendations
+# Testing recommendations
 
 In this guide, we will provide a roadmap and best-practices for creating test
 suites for python projects.
@@ -25,7 +21,7 @@ project to a reliable and maintainable state. We will also discuss some more
 specialized and advanced types of test cases in our
 [Taxonomy of Test Cases](#additional-types-of-test-suites) section.
 
-### Advantages of Testing
+## Advantages of Testing
 
 - Trustworthy code: Well tested code, is code that you can trust to behave as
   expected.
@@ -39,7 +35,7 @@ specialized and advanced types of test cases in our
   their changes do not break existing features, or cause unexpected
   side-effects.
 
-### Any test case is better than none
+## Any test case is better than none
 
 When in doubt, write the test that makes sense at the time.
 
@@ -53,7 +49,7 @@ bogged down in the taxonomy of test types. As you write and use your test suite,
 the reason for classifying and sorting some types of tests into different test
 suites will become apparent.
 
-### As long as that test is correct
+## As long as that test is correct
 
 It can be surprisingly easy to write a test that passes when it should fail,
 especially when using complicated mocks and fixtures. The best way to avoid this
@@ -69,7 +65,7 @@ the test-case to make sure it fails when the code is broken.
 
 (public-interface-tests)=
 
-### Public Interface Tests
+## Public Interface Tests
 
 A good place to start writing tests is from the perspective of a user of your
 module or library, as described in the [Test
@@ -93,7 +89,7 @@ your test suite(s) grow, taxonomy of test cases, the and the use/need for
 different kinds of tests will become more clear.
 :::
 
-### Test Suites
+## Test Suites
 
 Not all test cases are the same. In the following sections we will discuss many
 kinds of tests, which serve different purposes and provide different benefits.
@@ -107,7 +103,7 @@ time to set up and may depend on slow and unreliable external services. By
 organizing tests into suites based on execution time, you can run fast suites
 first and stop if an error is encountered before running slower suites.
 
-#### Advantages of Test Suites
+### Advantages of Test Suites
 
 - Developers can run relevant tests quickly and frequently.
 - Tests can 'Fail Fast', while still reporting all failures within that suite.
@@ -116,7 +112,7 @@ first and stop if an error is encountered before running slower suites.
 - We can avoid false positives, by not running tests we expect to fail due to
   external factors.
 
-#### Guidelines for Test Suites
+### Guidelines for Test Suites
 
 - Organize test cases into suites based on the type of test and execution time.
 - Set up test-runners (Make, shell scripts, CI/CD) to run fast suites first, and
@@ -124,7 +120,7 @@ first and stop if an error is encountered before running slower suites.
 - Use markers to enable developers to run the sub-sets of test which are most
   relevant to their work, with minimal time spent waiting.
 
-#### Creating Test Suites
+### Creating Test Suites
 
 The simplest way to start, is separating tests into directories inside of the
 `tests/` directory:
@@ -180,7 +176,7 @@ def pytest_collection_modifyitems(session, config, items):
 
 (project-level-integration-tests)=
 
-### Project Level Integration Tests
+## Project Level Integration Tests
 
 The term "Integration Test" is unfortunately overloaded, and used to describe
 testing that various components integrate with each other, at many levels of the
@@ -202,7 +198,7 @@ The intended audience for these tests is developers working on the project.
 
 (unit-tests)=
 
-### Unit Tests
+## Unit Tests
 
 Unit tests loosely follow the "London School" of testing, where the smallest
 unit of code is tested in isolation.
@@ -215,7 +211,7 @@ function, an attribute of an object, a method or property of a class.
 They test only the code in the project, not code imported from other projects
 (or even other modules within the same project).
 
-#### Advantages of unit testing
+### Advantages of unit testing
 
 Unit tests ensure that the code, as written, is correct, and executes properly.
 They communicate the intention of the creator of the code, how the code is
@@ -237,7 +233,7 @@ better design decisions:
   understand and maintain. Refactoring code to make it easier to test often
   leads us to write better code overall.
 
-#### When to write unit tests
+### When to write unit tests
 
 - When your project matures enough to justify the work! Higher-level testing is
   often sufficient for small projects which are not part of critical
@@ -257,7 +253,7 @@ better design decisions:
 Not all projects need full unit test coverage, some may not need unit tests at
 all.
 
-#### Guidelines for unit testing
+### Guidelines for unit testing
 
 - Unit tests live alongside the code they test, in a /tests folder. They should
   be in a different directory than higher-level tests (integration, e2e,
@@ -286,7 +282,7 @@ all.
   between units, and will correctly tell you which part is failing if one
   breaks.
 
-##### Importing in test files
+#### Importing in test files
 
 Keep things local! Prefer to import only from the file-under-test when possible.
 This helps keep the context of the unit tests focused on the file-under-test.
@@ -389,7 +385,7 @@ from bettermath import superfast_numeric_sum as numeric_sum
 total = numeric_sum(some_numeric_values)
 ```
 
-##### Running unit tests
+#### Running unit tests
 
 We recommend using Pytest for running tests in your development environments. To
 run unit tests in your source folder, from your package root, use
@@ -402,7 +398,7 @@ pytest](pages/guides/pytest#configuring-pytest)
 We recommend configuring pytest to run ONLY your fastest, least demanding test
 suite by default.
 
-##### Mocking and Patching to Isolate the code under test
+#### Mocking and Patching to Isolate the code under test
 
 When the unit you are testing touches any external unit (usually something you
 imported, or another unit that has its own tests), the external unit should be
@@ -480,7 +476,7 @@ def test_pytest(mocker):
     dangerous_sideffects()
 ```
 
-### Extensive Input Testing
+## Extensive Input Testing
 
 The range of inputs that test cases validate is an important decision.
 
@@ -501,7 +497,7 @@ readable), and technical (complex, extensive) test files.
 - [Fuzz Tests](#fuzz-tests) are the best place to handle extensive and
   exhaustive input testing.
 
-#### In Public Interface Tests
+### In Public Interface Tests
 
 These are the most appropriate place to test certain invalid inputs and
 dependencies. Public Interface tests act like a contract with users; each
@@ -510,14 +506,14 @@ that it will not change without warning (and probably a major version bump). So
 any input/output and side-effects included in these tests should be considered
 _officially supported behavior_ and given careful consideration.
 
-#### In project level integration tests
+### In project level integration tests
 
 These are a good place to handle more extensive input testing. Integration tests
 already tend to be more verbose, with a lot of setup and teardown, and much more
 behavior to cover than other kinds of tests. These are the kinds of tests that
 should focus on edgecases.
 
-#### In Unit Tests
+### In Unit Tests
 
 Unit Tests should focus on the "happy-path" of execution. In most cases one
 representative example of the _expected_ input is sufficient. The test case
@@ -547,7 +543,7 @@ def bar(x):
 
 (additional-types-of-test-suites)=
 
-### Additional Types of Test Suites
+## Additional Types of Test Suites
 
 A non-exhaustive discussion of some common types of tests.
 
@@ -556,7 +552,7 @@ Dont Panic!
 Depending on your project, you may not need many, or most of these kinds of
 tests.
 
-#### Behavioral, Feature, or Functional Tests
+### Behavioral, Feature, or Functional Tests
 
 High-level tests, which ensure a specific feature works. These are placed in a
 location like 'project_root/tests/behavioral/'. Used for testing things like:
@@ -567,7 +563,7 @@ location like 'project_root/tests/behavioral/'. Used for testing things like:
 
 (fuzz-tests)=
 
-#### Fuzz Tests
+### Fuzz Tests
 
 Fuzz tests attempt to test the full range of possible inputs to a function. They
 are good for finding edge-cases, where what should be valid input causes a
@@ -579,7 +575,7 @@ excellent tool for this, and a lot of fun to use.
   [see: fail fast](https://en.wikipedia.org/wiki/Fail-fast_system)
 - Reserve fuzz testing for the few critical functions, where it really matters.
 
-#### Integration Tests
+### Integration Tests
 
 The word "Integration" is a bit overloaded, and can refer to many levels of
 interaction between your code, its dependencies, and external systems.
@@ -602,7 +598,7 @@ interaction between your code, its dependencies, and external systems.
 
 (end-to-end-tests)=
 
-#### End to End Tests
+### End to End Tests
 
 The slowest, and most brittle, of all tests. Here, you set up an entire
 production-like system, and run tests against it. Some examples are:
@@ -614,7 +610,7 @@ production-like system, and run tests against it. Some examples are:
 - Processing data from a pre-loaded test database
 - Manual QA testing
 
-#### Fuzz Tests and other slow tests
+### Fuzz Tests and other slow tests
 
 Testing random input, using tools like Hypothesis, is similar to testing edge
 cases, but running these tests can take a very long time, and they can often be
@@ -627,7 +623,7 @@ much more complex and difficult to read for new developers.
 - These can take an arbitrarily long time to run, and you will need to set
   reasonable limits for your project.
 
-### Diagnostic Tests
+## Diagnostic Tests
 
 Diagnostic tests are used to verify the installation of a package. They should
 be runnable on production systems, like when we need to ssh into a live server
@@ -646,14 +642,14 @@ a full system check of the package. Good diagnostic tests:
 - Run quickly: select tests that can be run in a few moments
 - Provide meaningful feedback
 
-#### Advantages of Diagnostic Tests
+### Advantages of Diagnostic Tests
 
 - Diagnostic tests allow us to verify an installation of a package.
 - They can be used to verify system-level dependencies like:
   - Compiled binary dependencies
   - Access to specific hardware, like GPUs
 
-#### Guidelines for Diagnostic Tests
+### Guidelines for Diagnostic Tests
 
 - Consider using the stdlib `unittest.TestCase` and other stdlib tools instead
   of pytest. To allow running unit tests for diagnostics in production
@@ -662,7 +658,7 @@ a full system check of the package. Good diagnostic tests:
 - Test files should be named `test_<file under test>.py`, so that stdlib
   unittest can find them easily.
 
-#### Mocking and Patching to Isolate the code under test
+### Mocking and Patching to Isolate the code under test
 
 Test Isolation is less necessary in diagnostic tests than unit tests. We often
 want diagnostic tests to execute compiled code, or run a test on GPU hardware.
@@ -682,7 +678,7 @@ def test_myfunction(t, patchme: Mock):
     t.assertIs(ret, patchme.return_value)
 ```
 
-#### Running Diagnostic Tests
+### Running Diagnostic Tests
 
 stdlib's unittest can be used in environments where pytest is not available:
 

--- a/docs/pages/tutorials/dev-environment.md
+++ b/docs/pages/tutorials/dev-environment.md
@@ -1,15 +1,11 @@
----
-title: Intro to development
----
-
-## Intro to development
+# Intro to development
 
 In this section you will:
 
 - Create an isolated software area ("virtual environment") to work in.
 - Open a code editor.
 
-### Development environment
+## Development environment
 
 If you want to work on Python software, you should _always_ have a virtual
 environment, an area to install the software that is isolated from other
@@ -27,7 +23,7 @@ There are many (arguably _too_ many) ways to do this in Python. Any modern tool
 should be fine, but here we recommend two options popular in the scientific
 Python community. If you already use a different way, that's fine, use that.
 
-#### Option 1: Using pip
+### Option 1: Using pip
 
 The most basic option is to use `venv`, which comes by default with Python.
 
@@ -93,7 +89,7 @@ you were at some past point in time.
 
 [uv]: https://github.com/astral-sh/uv
 
-#### Option 2: Using conda
+### Option 2: Using conda
 
 You can also develop in conda. This is an especially good option if:
 
@@ -129,7 +125,7 @@ To deactivate, use `conda deactivate`, or leave your shell.
 
 [pixi]: https://pixi.sh
 
-### Choosing an Editor
+## Choosing an Editor
 
 Any plain text editor will serve our purposes for this guide. Bare bones editors
 like Notepad or `nano` will do the job. More feature-rich Integrated Development

--- a/docs/pages/tutorials/docs.md
+++ b/docs/pages/tutorials/docs.md
@@ -1,10 +1,6 @@
----
-title: Writing documentation
----
+# Writing documentation
 
-## Writing documentation
-
-### Build the documentation
+## Build the documentation
 
 Scientific Python software documentation can be written in the Markdown syntax,
 which looks like this:
@@ -95,7 +91,7 @@ You should see some log message ending in `build succeeded.` This created the
 directory `docs/build`. Open `docs/build/index.html` in your web browser to view
 the documentation.
 
-### Essential Features of MyST Markdown
+## Essential Features of MyST Markdown
 
 We refer you to the [MyST][] documentation for topics including:
 
@@ -106,7 +102,7 @@ We refer you to the [MyST][] documentation for topics including:
 - Math and equations
 - Including content from other files
 
-### Structure
+## Structure
 
 We began with this structure, having a single documentation page.
 
@@ -145,7 +141,7 @@ tutorials/real-application.md
 
 For more details see the MyST documentation page on [organizing content][].
 
-### Automatically generate reference documentation
+## Automatically generate reference documentation
 
 Reference documentation provides comprehensive documentation of the API: all the
 inputs and outputs of every public object in the codebase. This should not be

--- a/docs/pages/tutorials/index.md
+++ b/docs/pages/tutorials/index.md
@@ -1,8 +1,4 @@
----
-title: Tutorials
----
-
-## Tutorials
+# Tutorials
 
 Do you have a pile of scientific Python scripts or Jupyter notebooks that are
 becoming unwieldy? Are changes to some parts of your code accidentally breaking

--- a/docs/pages/tutorials/module.md
+++ b/docs/pages/tutorials/module.md
@@ -1,15 +1,11 @@
----
-title: Inline documentation
----
-
-## Inline documentation
+# Inline documentation
 
 In this section, you will:
 
 - Place some code in a module.
 - Provide inline documentation (a "docstring").
 
-### Module
+## Module
 
 As a concrete example, let's suppose we have a simple function that encodes
 [Snell's Law][]. Perhaps this function currently lives in a Jupyter notebook or

--- a/docs/pages/tutorials/packaging.md
+++ b/docs/pages/tutorials/packaging.md
@@ -1,8 +1,4 @@
----
-title: Packaging
----
-
-## Packaging
+# Packaging
 
 In the section you will:
 
@@ -12,7 +8,7 @@ In the section you will:
 
 For more about packaging, see our [packaging guide][].
 
-### Create a minimal installable Python package
+## Create a minimal installable Python package
 
 Let’s create a Python package that contains this function.
 
@@ -90,7 +86,7 @@ At this point, your package's file structure will look like
 │       └── refraction.py
 ```
 
-### Install and use your package
+## Install and use your package
 
 Now that your package has the necessary elements, you can install it into your
 virtual environment (which should already be active). From the top level of your

--- a/docs/pages/tutorials/test.md
+++ b/docs/pages/tutorials/test.md
@@ -1,8 +1,4 @@
----
-title: Test
----
-
-## Test
+# Test
 
 In this section you will:
 
@@ -16,7 +12,7 @@ unintended changes or breakage with not go unnoticed. Writing tests also tends
 to encouraging you to write modular, reusable code, because it is easier to
 test.
 
-### Write some tests
+## Write some tests
 
 Make a directory for tests. We recommend putting it next to the `src` directory.
 
@@ -94,7 +90,7 @@ Things to notice:
   be using below.) This allows you to also write helper functions that are not
   tests.
 
-### Run the tests
+## Run the tests
 
 Scientific Python packages generally use a program called `pytest` to run their
 tests and report successes and failures. Install `pytest`.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

Follow-up to #801. On the mystmd site every page showed its title twice, and the landing page rendered a bare **Home** heading above the content ([review note](https://github.com/scientific-python/cookie/pull/801#issuecomment-4693382740)).

## Root cause

The mystmd migration (#792) gave every page a frontmatter `title:` **and** demoted the original `#` page heading to `##`. The book-theme renders the frontmatter `title` as a title-block H1, so the `##` heading below it became a visible duplicate. On `index.md` the title was `Home`, so the page led with a stray "Home" H1.

## Fix

For each page, drop the redundant frontmatter `title` and promote body headings back up one level. MyST then extracts the single `#` H1 as the page title (rendered once in the title block), and sections nest correctly beneath it.

- `short_title` still drives the nav labels on the GHA/style pages; their title block now shows the fuller heading instead of the terse duplicate.
- `index.md` keeps a `short_title: Home` nav label while its title becomes _Scientific Python Library Development Guide_.
- `packaging_simple.md` / `packaging_compiled.md` had a `tip`/cog block before the heading (which blocks MyST title extraction), so their `#` heading moves to the top.

## Verification

- Built with `mystmd` and walked the rendered mdast for all pages: every page has a correct title and **zero** body headings duplicating it.
- `prek -a` passes fully, including `rumdl` (MD041), `blacken-docs`, and **Cog the pages** (the cog reorder in `packaging_compiled` regenerates cleanly).
- The diff only touches headings and frontmatter — no prose or code changes.

The other review notes are theme work (tab selection, configurable highlight scheme, three-way theme toggle) tracked separately; the site already renders the nav/outline table of contents.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--805.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->