### PR TITLE
chore: update webapp to repo-review 1.2.0

### DIFF
--- a/docs/pages/guides/repo_review.md
+++ b/docs/pages/guides/repo_review.md
@@ -18,11 +18,11 @@ pipx run 'sp-repo-review[cli]' <path to repo>
 ---
 
 <!-- rumdl-disable-next-line MD034 -->
-:::{anywidget} https://cdn.jsdelivr.net/npm/repo-review-webapp@1.1.3/dist/repo-review-anywidget.mjs
+:::{anywidget} https://cdn.jsdelivr.net/npm/repo-review-webapp@1.2.0/dist/repo-review-anywidget.mjs
 {
   "url_sync": true,
   "deps": [
-    "repo-review~=1.1.0",
+    "repo-review~=1.2.0",
     "sp-repo-review==2026.04.04",
     "validate-pyproject[all]~=0.25.0",
     "validate-pyproject-schema-store==2026.04.03",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Updates the embedded repo-review webapp to [1.2.0](https://github.com/scientific-python/repo-review/releases/tag/v1.2.0).

## Changes
In the `{anywidget}` embed (`docs/pages/guides/repo_review.md`):
- `repo-review-webapp@1.1.3` → `@1.2.0`
- `repo-review~=1.1.0` → `~=1.2.0`

## Notes
The headline 1.2.0 webapp change — running Pyodide in a web worker — is internal to the bundle (the worker is created from a Blob URL), so the anywidget embed API (`url_sync`/`deps` options and the `repo-review-anywidget.mjs` export path) is unchanged. Only version pins needed updating.

The `sp_repo_review` Python code only uses the plugin entry-point interface, so it's unaffected by the `GHPath` traversal fix. The full test suite passes against `repo-review==1.2.0` (245 passed, 1 skipped).

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--806.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->