### PR TITLE
fix(ci): correct unsound ternary in alls-green allowed-skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,22 +56,22 @@ jobs:
         with:
           allowed-skips: >-
             ${{
-              fromJSON(needs.change-detection.outputs.run-cookie)
-              && ''
-              || '
+              !fromJSON(needs.change-detection.outputs.run-cookie)
+              && '
               cookie,
               '
+              || ''
             }} ${{
-              fromJSON(needs.change-detection.outputs.run-rr)
-              && ''
-              || '
+              !fromJSON(needs.change-detection.outputs.run-rr)
+              && '
               rr-tests,
               '
+              || ''
             }} ${{
-              fromJSON(needs.change-detection.outputs.run-docs)
-              && ''
-              || '
+              !fromJSON(needs.change-detection.outputs.run-docs)
+              && '
               docs,
               '
+              || ''
             }}
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The zizmor bump in #812 (`v1.25.2` → `v1.26.1`) added the [`unsound-ternary`](https://docs.zizmor.sh/audits/#unsound-ternary) audit, which fails pre-commit.ci on this repo's own `ci.yml`.

It's a real bug. The `allowed-skips` expressions used `fromJSON(...) && '' || 'value'`. GitHub's `a && b || c` ternary only works when `b` is truthy; here `b` is `''`, so a **true** condition evaluates `cond && ''` → `''` → falls through to the `|| 'value'` branch every time. Net effect: every job was always listed in `allowed-skips` regardless of change-detection, defeating the guard against unexpected skips.

This inverts each condition so the value lives in the truthy branch (`!fromJSON(...) && 'value' || ''`), which is sound and does what was intended.

Verified against the bumped zizmor: `zizmor` passes and a full `prek run -a` is green. The pattern only existed in this repo's own `ci.yml`, not in the templated output.

Once merged, re-running pre-commit.ci on #812 should pass.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--815.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->