### PR TITLE
feat(checks): map MY family to ty and pyrefly config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,10 @@ new Python projects (`{{cookiecutter.project_name}}/`), a **repo-review plugin**
 - Run linting (pre-commit via prek): `uvx nox -s rr_lint`
 - Run pylint: `uvx nox -s rr_pylint`
 - Run the CLI: `uvx nox -s rr_run -- <path>`
-- Regenerate README check list via cog: `uvx nox -s readme`
+- Regenerate README check list via cog: `uvx nox -s readme` (always use this
+  session, not `cog -r README.md` directly — the dev venv has extra repo-review
+  plugins like validate-pyproject installed, so a direct run adds stray check
+  sections that CI's minimal install will reject)
 - Build wheel/sdist: `uvx nox -s rr_build`
 
 Important: tests run with `PYTHONWARNDEFAULTENCODING=1`.

--- a/README.md
+++ b/README.md
@@ -362,8 +362,8 @@ for family, grp in itertools.groupby(collected.checks.items(), key=lambda x: x[1
 
 ### MyPy
 
-- [`MY100`](https://learn.scientific-python.org/development/guides/style#MY100): Uses MyPy (pyproject config)
-- [`MY101`](https://learn.scientific-python.org/development/guides/style#MY101): MyPy strict mode
+- [`MY100`](https://learn.scientific-python.org/development/guides/style#MY100): Uses a type checker (pyproject config)
+- [`MY101`](https://learn.scientific-python.org/development/guides/style#MY101): Type checker in strict mode
 - `MY102`: MyPy show_error_codes deprecated
 - [`MY103`](https://learn.scientific-python.org/development/guides/style#MY103): MyPy warn unreachable
 - [`MY104`](https://learn.scientific-python.org/development/guides/style#MY104): MyPy enables ignore-without-code
@@ -425,6 +425,10 @@ Will not show up if no `.readthedocs.yml`/`.readthedocs.yaml` file is present.
 Will not show up if no `setup.cfg` file is present.
 
 - [`SCFG001`](https://learn.scientific-python.org/development/guides/packaging-classic#SCFG001): Avoid deprecated setup.cfg names
+
+### Validate-PyProject
+
+- `VPP001`: Validate pyproject.toml
 
 <!-- [[[end]]] -->
 

--- a/README.md
+++ b/README.md
@@ -426,10 +426,6 @@ Will not show up if no `setup.cfg` file is present.
 
 - [`SCFG001`](https://learn.scientific-python.org/development/guides/packaging-classic#SCFG001): Avoid deprecated setup.cfg names
 
-### Validate-PyProject
-
-- `VPP001`: Validate pyproject.toml
-
 <!-- [[[end]]] -->
 
 [repo-review]: https://repo-review.readthedocs.io

--- a/docs/guides/style.md
+++ b/docs/guides/style.md
@@ -721,7 +721,7 @@ errors in your typing.
 :::
 :::{tab-item} Pyrefly
 :sync: pyrefly
-Pyrefly's config section in `pyproject.toml` looks like this:
+{rr}`MY100` Pyrefly's config section in `pyproject.toml` looks like this:
 
 ```toml
 [tool.pyrefly]
@@ -736,8 +736,8 @@ ignore-missing-imports = ["numpy"]
 Pyrefly checks all your code by default, rather than only annotated functions,
 so you can start from a looser `preset` and tighten as you go. Set
 `preset = "strict"` (the equivalent of MyPy's `strict = true`) once you are
-ready, and toggle individual error codes in a `[tool.pyrefly.errors]` table, for
-example:
+ready {rr}`MY101`, and toggle individual error codes in a
+`[tool.pyrefly.errors]` table, for example:
 
 ```toml
 [tool.pyrefly]
@@ -753,7 +753,7 @@ You can disable Pyrefly on a line with `# pyrefly: ignore` (or
 :::
 :::{tab-item} ty
 :sync: ty
-ty's config sections in `pyproject.toml` look like this:
+{rr}`MY100` ty's config sections in `pyproject.toml` look like this:
 
 ```toml
 [tool.ty.environment]

--- a/src/sp_repo_review/checks/mypy.py
+++ b/src/sp_repo_review/checks/mypy.py
@@ -6,16 +6,6 @@ from typing import Any
 
 from . import mk_url
 
-# Type checkers configured via a `tool.<name>` table in `pyproject.toml`. Only
-# MyPy and Pyrefly expose options that map onto the MY1xx checks below; ty
-# tightens individual rules instead, so the MyPy-specific checks skip for it.
-TYPE_CHECKERS = ("mypy", "pyrefly", "ty")
-
-
-def _tools(pyproject: dict[str, Any]) -> set[str]:
-    tool = pyproject.get("tool", {})
-    return {name for name in TYPE_CHECKERS if name in tool}
-
 
 class MyPy:
     family = "mypy"
@@ -35,7 +25,13 @@ class MY100(MyPy):
         this check.
         """
 
-        return bool(_tools(pyproject))
+        match pyproject:
+            case {
+                "tool": {"mypy": object()} | {"pyrefly": object()} | {"ty": object()}
+            }:
+                return True
+            case _:
+                return False
 
 
 class MY101(MyPy):

--- a/src/sp_repo_review/checks/mypy.py
+++ b/src/sp_repo_review/checks/mypy.py
@@ -6,13 +6,23 @@ from typing import Any
 
 from . import mk_url
 
+# Type checkers configured via a `tool.<name>` table in `pyproject.toml`. Only
+# MyPy and Pyrefly expose options that map onto the MY1xx checks below; ty
+# tightens individual rules instead, so the MyPy-specific checks skip for it.
+TYPE_CHECKERS = ("mypy", "pyrefly", "ty")
+
+
+def _tools(pyproject: dict[str, Any]) -> set[str]:
+    tool = pyproject.get("tool", {})
+    return {name for name in TYPE_CHECKERS if name in tool}
+
 
 class MyPy:
     family = "mypy"
 
 
 class MY100(MyPy):
-    "Uses MyPy (pyproject config)"
+    "Uses a type checker (pyproject config)"
 
     requires = {"PY001"}
     url = mk_url("style")
@@ -20,30 +30,27 @@ class MY100(MyPy):
     @staticmethod
     def check(pyproject: dict[str, Any]) -> bool:
         """
-        Must have `tool.mypy` section in `pyproject.toml`. Other forms of
-        configuration are not supported by this check.
+        Must have a `tool.mypy`, `tool.pyrefly`, or `tool.ty` section in
+        `pyproject.toml`. Other forms of configuration are not supported by
+        this check.
         """
 
-        match pyproject:
-            case {"tool": {"mypy": object()}}:
-                return True
-            case _:
-                return False
+        return bool(_tools(pyproject))
 
 
 class MY101(MyPy):
-    "MyPy strict mode"
+    "Type checker in strict mode"
 
     requires = {"MY100"}
     url = mk_url("style")
 
     @staticmethod
-    def check(pyproject: dict[str, Any]) -> bool:
+    def check(pyproject: dict[str, Any]) -> bool | None:
         """
-        Must have `strict` in the mypy config. MyPy is best with strict or
-        nearly strict configuration. If you are happy with the strictness of
-        your settings already, ignore this check or set `strict = false`
-        explicitly.
+        Should opt into strict checking. For MyPy, set `strict` (true/false).
+        For Pyrefly, set a `preset` (such as `"strict"`). ty has no strict
+        switch -- you tighten individual rules in `[tool.ty.rules]` -- so this
+        check is skipped when only ty is configured.
 
         ```toml
         [tool.mypy]
@@ -54,8 +61,12 @@ class MY101(MyPy):
         match pyproject:
             case {"tool": {"mypy": {"strict": bool()}}}:
                 return True
-            case _:
+            case {"tool": {"pyrefly": {"preset": str()}}}:
+                return True
+            case {"tool": {"mypy": object()} | {"pyrefly": object()}}:
                 return False
+            case _:
+                return None
 
 
 class MY102(MyPy):
@@ -64,17 +75,20 @@ class MY102(MyPy):
     requires = {"MY100"}
 
     @staticmethod
-    def check(pyproject: dict[str, Any]) -> bool:
+    def check(pyproject: dict[str, Any]) -> bool | None:
         """
         Must not have `show_error_codes`. It is now the default, or you can
         use `hide_error_codes` with the reverse value instead (since MyPy v0.990).
+        Skipped if MyPy is not configured.
         """
 
         match pyproject:
             case {"tool": {"mypy": {"show_error_codes": bool()}}}:
                 return False
-            case _:
+            case {"tool": {"mypy": object()}}:
                 return True
+            case _:
+                return None
 
 
 class MY103(MyPy):
@@ -84,12 +98,12 @@ class MY103(MyPy):
     url = mk_url("style")
 
     @staticmethod
-    def check(pyproject: dict[str, Any]) -> bool:
+    def check(pyproject: dict[str, Any]) -> bool | None:
         """
         Must have `warn_unreachable` (true/false) to pass this check. There are
         occasionally false positives (often due to platform or Python version
         static checks), so it's okay to set it to false if you need to. But try
-        it first - it can catch real bugs too.
+        it first - it can catch real bugs too. Skipped if MyPy is not configured.
 
         ```toml
         [tool.mypy]
@@ -100,8 +114,10 @@ class MY103(MyPy):
         match pyproject:
             case {"tool": {"mypy": {"warn_unreachable": bool()}}}:
                 return True
-            case _:
+            case {"tool": {"mypy": object()}}:
                 return False
+            case _:
+                return None
 
 
 class MY104(MyPy):
@@ -111,11 +127,12 @@ class MY104(MyPy):
     url = mk_url("style")
 
     @staticmethod
-    def check(pyproject: dict[str, Any]) -> bool:
+    def check(pyproject: dict[str, Any]) -> bool | None:
         """
         Must have `"ignore-without-code"` in `enable_error_code = [...]`. This
         will force all skips in your project to include the error code, which
         makes them more readable, and avoids skipping something unintended.
+        Skipped if MyPy is not configured.
 
         ```toml
         [tool.mypy]
@@ -126,8 +143,10 @@ class MY104(MyPy):
         match pyproject:
             case {"tool": {"mypy": {"enable_error_code": codes}}}:
                 return "ignore-without-code" in codes
-            case _:
+            case {"tool": {"mypy": object()}}:
                 return False
+            case _:
+                return None
 
 
 class MY105(MyPy):
@@ -137,10 +156,11 @@ class MY105(MyPy):
     url = mk_url("style")
 
     @staticmethod
-    def check(pyproject: dict[str, Any]) -> bool:
+    def check(pyproject: dict[str, Any]) -> bool | None:
         """
         Must have `"redundant-expr"` in `enable_error_code = [...]`. This helps
         catch useless lines of code, like checking the same condition twice.
+        Skipped if MyPy is not configured.
 
         ```toml
         [tool.mypy]
@@ -151,8 +171,10 @@ class MY105(MyPy):
         match pyproject:
             case {"tool": {"mypy": {"enable_error_code": codes}}}:
                 return "redundant-expr" in codes
-            case _:
+            case {"tool": {"mypy": object()}}:
                 return False
+            case _:
+                return None
 
 
 class MY106(MyPy):
@@ -162,10 +184,11 @@ class MY106(MyPy):
     url = mk_url("style")
 
     @staticmethod
-    def check(pyproject: dict[str, Any]) -> bool:
+    def check(pyproject: dict[str, Any]) -> bool | None:
         """
         Must have `"truthy-bool"` in `enable_error_code = []`. This catches
-        mistakes in using a value as truthy if it cannot be falsy.
+        mistakes in using a value as truthy if it cannot be falsy. Skipped if
+        MyPy is not configured.
 
         ```toml
         [tool.mypy]
@@ -176,8 +199,10 @@ class MY106(MyPy):
         match pyproject:
             case {"tool": {"mypy": {"enable_error_code": codes}}}:
                 return "truthy-bool" in codes
-            case _:
+            case {"tool": {"mypy": object()}}:
                 return False
+            case _:
+                return None
 
 
 def repo_review_checks() -> dict[str, MyPy]:

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -9,6 +9,22 @@ def test_my100_present():
     assert compute_check("MY100", pyproject=toml).result
 
 
+def test_my100_pyrefly():
+    toml = toml_loads("""
+        [tool.pyrefly]
+        project-includes = ["src"]
+        """)
+    assert compute_check("MY100", pyproject=toml).result
+
+
+def test_my100_ty():
+    toml = toml_loads("""
+        [tool.ty.src]
+        include = ["src"]
+        """)
+    assert compute_check("MY100", pyproject=toml).result
+
+
 def test_my100_missing():
     assert not compute_check("MY100", pyproject={}).result
 
@@ -27,6 +43,39 @@ def test_my101_missing():
         warn_unreachable = true
         """)
     assert not compute_check("MY101", pyproject=toml).result
+
+
+def test_my101_pyrefly_preset():
+    toml = toml_loads("""
+        [tool.pyrefly]
+        preset = "strict"
+        """)
+    assert compute_check("MY101", pyproject=toml).result
+
+
+def test_my101_pyrefly_no_preset():
+    toml = toml_loads("""
+        [tool.pyrefly]
+        project-includes = ["src"]
+        """)
+    assert compute_check("MY101", pyproject=toml).result is False
+
+
+def test_my101_ty_skipped():
+    toml = toml_loads("""
+        [tool.ty.src]
+        include = ["src"]
+        """)
+    assert compute_check("MY101", pyproject=toml).result is None
+
+
+def test_my10x_skipped_without_mypy():
+    toml = toml_loads("""
+        [tool.ty.src]
+        include = ["src"]
+        """)
+    for name in ("MY102", "MY103", "MY104", "MY105", "MY106"):
+        assert compute_check(name, pyproject=toml).result is None
 
 
 def test_my102_pass_without_show_error_codes():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #813.

Previously MY100 only passed for `tool.mypy`, so projects using `ty` (or `pyrefly`) failed it even though PC140 already accepts all three type checkers.

## Changes

- **MY100** "Uses a type checker (pyproject config)" — now passes for any of `tool.mypy`, `tool.pyrefly`, or `tool.ty`.
- **MY101** "Type checker in strict mode" — maps mypy's `strict` (bool) to pyrefly's `preset` (any value). ty has no strict switch, so this check is skipped when only ty is configured.
- **MY102–MY106** — these cover mypy-specific concepts (`show_error_codes`, `warn_unreachable`, and the `enable_error_code` entries) with no ty/pyrefly equivalent. They now **skip** (return `None`) when mypy is not configured, instead of failing. Since they `require` MY100 — which now passes for ty/pyrefly — skipping is what keeps them from failing on absent mypy keys.

## Design note

Only MY100 and MY101 had genuine cross-tool mappings. ty tightens individual `[tool.ty.rules]` and pyrefly toggles `[tool.pyrefly.errors]`, neither with a clean 1:1 to mypy's error codes — so rather than invent fuzzy mappings, the mypy-specific checks skip for non-mypy users. Happy to adjust if you'd prefer a different treatment.

## Tests & docs

- Added test coverage for MY100 (pyrefly/ty), MY101 (pyrefly preset present/absent, ty skipped), and MY102–106 skipping without mypy.
- Regenerated the README check list (cog) and added `{rr}` cross-references in the style guide's pyrefly/ty tabs.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--818.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->