### PR TITLE
feat: check for a gitignore file

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ for family, grp in itertools.groupby(collected.checks.items(), key=lambda x: x[1
 - [`PY005`](https://learn.scientific-python.org/development/guides/packaging-simple#PY005): Has tests folder
 - [`PY006`](https://learn.scientific-python.org/development/guides/style#PY006): Has pre-commit config
 - [`PY007`](https://learn.scientific-python.org/development/guides/tasks#PY007): Supports an easy task runner (nox, tox, pixi, etc.)
+- [`PY008`](https://learn.scientific-python.org/development/guides/packaging-simple#PY008): Has a .gitignore file
 
 ### PyProject
 

--- a/docs/guides/packaging_simple.md
+++ b/docs/guides/packaging_simple.md
@@ -175,8 +175,8 @@ support versioning.
 This is tool specific.
 
 - [Hatchling info here](https://hatch.pypa.io/latest/config/build/#file-selection).
-  Hatchling uses your VCS ignore file by default, so make sure it is accurate
-  (which is a good idea anyway).
+  {rr}`PY008` Hatchling uses your VCS ignore file by default, so make sure your
+  project has an accurate `.gitignore` file (which is a good idea anyway).
 - [Flit info here](https://flit.readthedocs.io/en/latest/pyproject_toml.html#sdist-section).
   Flit requires manual inclusion/exclusion in many cases, like using a dirty
   working directory.

--- a/src/sp_repo_review/checks/general.py
+++ b/src/sp_repo_review/checks/general.py
@@ -159,5 +159,16 @@ class PY007(General):
                 return False
 
 
+class PY008(General):
+    "Has a .gitignore file"
+
+    url = mk_url("packaging-simple")
+
+    @staticmethod
+    def check(root: Traversable) -> bool:
+        "Projects must have a `.gitignore` file"
+        return root.joinpath(".gitignore").is_file()
+
+
 def repo_review_checks() -> dict[str, General]:
     return {p.__name__: p() for p in General.__subclasses__()}

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -171,3 +171,23 @@ def test_py007_missing(tmp_path: Path):
     simple = tmp_path / "simple"
     simple.mkdir()
     assert not compute_check("PY007", root=simple, pyproject={}).result
+
+
+def test_py008(tmp_path: Path):
+    simple = tmp_path / "simple"
+    simple.mkdir()
+    simple.joinpath(".gitignore").touch()
+    assert compute_check("PY008", root=simple).result
+
+
+def test_py008_not_file(tmp_path: Path):
+    simple = tmp_path / "simple"
+    simple.mkdir()
+    simple.joinpath(".gitignore").mkdir()
+    assert not compute_check("PY008", root=simple).result
+
+
+def test_py008_missing(tmp_path: Path):
+    simple = tmp_path / "simple"
+    simple.mkdir()
+    assert not compute_check("PY008", root=simple).result


### PR DESCRIPTION
## Summary

- add `PY008` to check that a project has a root `.gitignore` file
- cover present, missing, and directory-instead-of-file cases
- connect the new check to the packaging guide and regenerate the README check list

## Validation

- `uv run pytest -q` — 257 passed, 1 skipped (the existing rate-limit-sensitive package test)
- `uvx nox -s rr_lint`
- `uvx nox -s rr_pylint` — 10.00/10
- `uvx nox -s readme`
- `NODE_OPTIONS='--no-deprecation' npx --yes mystmd@^1.0 build --html`
- `git diff --check`

The exact `bun run build` wrapper was not run locally because Bun is unavailable in this environment; the MyST HTML build itself completed successfully via `npx`.

Fixes #822


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--827.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->