### PR TITLE
chore(deps): update mystmd to 1.10.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,11 +5,11 @@
     "": {
       "name": "scientific-python-development-guide",
       "dependencies": {
-        "mystmd": "^1.0",
+        "mystmd": "^1.10.1",
       },
     },
   },
   "packages": {
-    "mystmd": ["mystmd@1.9.1", "", { "bin": { "myst": "dist/myst.cjs" } }, "sha512-ya8u48V7Hn2EtE6DJTEtrWCZEnpIboiN5Ed6lDlvMikiSk8NHUxpocR2okf3BF8vNlC7Auj5s3T/Ulj3taN6bQ=="],
+    "mystmd": ["mystmd@1.10.1", "", { "bin": { "myst": "dist/myst.cjs" } }, "sha512-nczabm7R8PmoqJVqKpaijTr1kxdwnY+hRoFC7b+NEUdxW5yZZ8n/CuJlMJKlHtG/pA4o3Ia2RP/0Ra3UPj6sFg=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "scientific-python-development-guide",
       "dependencies": {
-        "mystmd": "^1.10.1",
+        "mystmd": "^1.10",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "clean": "rm -rf docs/_build"
   },
   "dependencies": {
-    "mystmd": "^1.0"
+    "mystmd": "^1.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "clean": "rm -rf docs/_build"
   },
   "dependencies": {
-    "mystmd": "^1.10.1"
+    "mystmd": "^1.10"
   }
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Bumps `mystmd` from 1.9.1 to 1.10.1 in `package.json`/`bun.lock`.

The `book-theme` isn't pinned — mystmd fetches it fresh at build time (RTD installs mystmd unpinned and rebuilds), so any theme fix is picked up automatically on the next build with no repo change needed. Verified a clean local build against 1.10.1 with a freshly-downloaded theme.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--830.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->