### PR TITLE
docs: reorg for nested sections

### DIFF
--- a/docs/guides/gha_basic.md
+++ b/docs/guides/gha_basic.md
@@ -1,8 +1,8 @@
 ---
-short_title: GitHub Actions introduction
+short_title: Introduction
 ---
 
-# GitHub Actions: Intro
+# GitHub Actions: Introduction
 
 {rr}`GH100` The recommended CI for scientific Python projects is GitHub
 Actions (GHA), although its predecessor Azure is also in heavy usage, and other

--- a/docs/guides/gha_pure.md
+++ b/docs/guides/gha_pure.md
@@ -1,8 +1,8 @@
 ---
-short_title: GitHub Actions for pure Python wheels
+short_title: Pure Python projects
 ---
 
-# GitHub Actions: Pure Python wheels
+# GitHub Actions: Pure Python projects
 
 We will cover binary wheels [on the next page][], but if you do not have a
 compiled extension, this is called a universal (pure Python) package, and the

--- a/docs/guides/gha_wheels.md
+++ b/docs/guides/gha_wheels.md
@@ -1,8 +1,8 @@
 ---
-short_title: GitHub Actions for Binary Wheels
+short_title: Compiled projects
 ---
 
-# GitHub Actions: Binary wheels
+# GitHub Actions: Compiled projects
 
 Building binary wheels is a bit more involved, but can still be done effectively
 with GHA. This document will introduce [cibuildwheel][] for use in your project.

--- a/docs/guides/packaging_compiled.md
+++ b/docs/guides/packaging_compiled.md
@@ -1,4 +1,4 @@
-# Packaging Compiled Projects
+# Compiled packaging
 
 <!-- [[[cog
 from cog_helpers import code_fence, render_cookie, TOMLMatcher

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -22,14 +22,18 @@ project:
         - file: guides/pytest.md
         - file: guides/coverage.md
         - file: guides/docs.md
-        - file: guides/packaging_simple.md
-        - file: guides/packaging_compiled.md
-        - file: guides/packaging_classic.md
+        - title: Packaging
+          children:
+          - file: guides/packaging_simple.md
+          - file: guides/packaging_compiled.md
+          - file: guides/packaging_classic.md
         - file: guides/style.md
         - file: guides/typing.md
-        - file: guides/gha_basic.md
-        - file: guides/gha_pure.md
-        - file: guides/gha_wheels.md
+        - title: GitHub Actions
+          children:
+            - file: guides/gha_basic.md
+            - file: guides/gha_pure.md
+            - file: guides/gha_wheels.md
         - file: guides/security.md
         - file: guides/tasks.md
     - file: principles/index.md

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -24,9 +24,9 @@ project:
         - file: guides/docs.md
         - title: Packaging
           children:
-          - file: guides/packaging_simple.md
-          - file: guides/packaging_compiled.md
-          - file: guides/packaging_classic.md
+            - file: guides/packaging_simple.md
+            - file: guides/packaging_compiled.md
+            - file: guides/packaging_classic.md
         - file: guides/style.md
         - file: guides/typing.md
         - title: GitHub Actions


### PR DESCRIPTION
This helps with the growing number of sections (security and now #823). It gives a way to add #829 so it can be extended with pixi eventually. #834 isn't as bad when it's only inside a subsection.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--835.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->