### PR TITLE
fix: broken links reported by the learn site link check

### DIFF
--- a/docs/guides/docs.md
+++ b/docs/guides/docs.md
@@ -33,8 +33,8 @@ template. There are lots of options, though:
   creators of `mkdocs-material` and `mkdocstrings`, designed as a faster,
   simpler successor to MkDocs. Configured with TOML and largely compatible
   with `mkdocs-material` sites, but still in early development.
-- [MyST](mystmd.org): A powerful system for rendering markdown and notebooks.
-  Can also be used for docs, though, see
+- [MyST](https://mystmd.org): A powerful system for rendering markdown and
+  notebooks. Can also be used for docs, though, see
   [echopype](https://echopype.readthedocs.io). AKA JupyterBook.
 - [Great Docs](https://posit-dev.github.io/great-docs/): A system with minimal
   configuration and modern features for making docs, based on Quarto.

--- a/docs/principles/testing.md
+++ b/docs/principles/testing.md
@@ -12,9 +12,9 @@ the Features that your project provides. Then we will cover
 [Project Level Integration tests](#project-level-integration-tests), which test
 that the various parts of your package work together, and work with the other
 packages it depends on. Finally we will cover the venerable
-{ref}`Unit Test <unit-tests>`, which test the correctness of your code from a
-perspective internal to your codebase, tests individual units in isolation, and
-are optimized to run quickly and often.
+{ref}`Unit Test <unit-tests-principles>`, which test the correctness of your
+code from a perspective internal to your codebase, tests individual units in
+isolation, and are optimized to run quickly and often.
 
 These 3 test suites will cover the bulk of your testing needs and help get your
 project to a reliable and maintainable state. We will also discuss some more
@@ -97,11 +97,12 @@ Tests should be divided up into different Suites, which can be run independently
 of one another.
 
 Tests which "Fail Fast" save both developer and compute time. Some tests are by
-necessity very slow. {ref}`Unit Tests <unit-tests>` should run extremely quickly
-in just a few seconds at most, while [end-to-end](#end-to-end-tests) require
-time to set up and may depend on slow and unreliable external services. By
-organizing tests into suites based on execution time, you can run fast suites
-first and stop if an error is encountered before running slower suites.
+necessity very slow. {ref}`Unit Tests <unit-tests-principles>` should run
+extremely quickly in just a few seconds at most, while
+[end-to-end](#end-to-end-tests) require time to set up and may depend on slow
+and unreliable external services. By organizing tests into suites based on
+execution time, you can run fast suites first and stop if an error is
+encountered before running slower suites.
 
 ### Advantages of Test Suites
 
@@ -196,7 +197,7 @@ more extensive validation.
 
 The intended audience for these tests is developers working on the project.
 
-(unit-tests)=
+(unit-tests-principles)=
 
 ## Unit Tests
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The `netlify-plugin-checklinks` run on learn.scientific-python.org reported 4 failures in `/development/`, which is built from this repo. This fixes 3 of them.

- `docs/guides/docs.md`: the MyST link had no scheme, so it built as the site-relative path `/developmentmystmd.org` and 404d.
- `docs/principles/testing.md`: the explicit `(unit-tests)=` target collided with the implicit heading target from `## Unit tests` in `docs/guides/gha_basic.md`. MyST resolved both `{ref}` uses to the GitHub Actions guide instead of the section on the same page. Renamed to `unit-tests-principles`.

Checked with a local `myst build --html`: the built page now links to `#unit-tests-principles` and `https://mystmd.org`.

The 4th failure is `/development/guides/pytest#configuring-pytest`. The link works; MyST writes cross-page URLs without a trailing slash and Netlify redirects, which `hyperlink` reports as `fragment-redirect`. That needs a change on the learn site, not here.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--839.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->