### PR TITLE
docs: mention missing pages in category indexes

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -18,9 +18,9 @@ A section on CI follows, with a [general setup guide][gha_basic], and then two
 choices for using CI to distribute your package, one for
 [pure Python][gha_pure], and one for [compiled extensions][gha_wheels]. You can
 read about setting up good tests on the [pytest page][pytest], with
-[coverage][]. There's also a page on setting up [docs][], as well as pages on
-[security][] best practices and information on using [agentic AI][ai]
-responsibly.
+[coverage][]. There's also a page on setting up [docs][], a page on
+[task runners][tasks], as well as pages on [security][] best practices and
+information on using [agentic AI][ai] responsibly.
 
 :::{tip} New project template
 Once you have completed the guidelines, there is a
@@ -48,6 +48,7 @@ WebAssembly! All checks point to a linked badge in the guide.
 [gha_pure]:           /guides/gha_pure.md
 [gha_wheels]:         /guides/gha_wheels.md
 [security]:           /guides/security.md
+[tasks]:              /guides/tasks.md
 [ai]:                 /guides/ai.md
 [pytest]:             /guides/pytest.md
 [right in the guide]: /guides/repo_review.md

--- a/docs/principles/index.md
+++ b/docs/principles/index.md
@@ -3,10 +3,12 @@
 These pages are focused on designing good software, with a focus on end-user
 research code. [Process recommendations][] discusses the process of writing
 software, and [Design recommendations][] covers some tips about writing easy to
-read and maintain code.
+read and maintain code. [Testing recommendations][] covers how to build a test
+suite for your project.
 
 [Process recommendations]: /principles/process.md
 [Design recommendations]: /principles/design.md
+[Testing recommendations]: /principles/testing.md
 
 
 ```{tableofcontents}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Two pages were not mentioned in the prose of their category index after the `pages/` reorg (dc834bb):

- `guides/tasks.md` (Task runners) in `guides/index.md`
- `principles/testing.md` (Testing recommendations) in `principles/index.md`

The `patterns` index already covered all of its pages, and the `tutorials` index only uses `{tableofcontents}`.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--840.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->