### PR TITLE
docs: simplify titles a bit

### DIFF
--- a/docs/guides/coverage.md
+++ b/docs/guides/coverage.md
@@ -1,4 +1,4 @@
-# Code Coverage
+# Coverage
 
 The "Code coverage" value of a codebase indicates how much of the
 production/development code is covered by the running unit tests. Maintainers

--- a/docs/guides/docs.md
+++ b/docs/guides/docs.md
@@ -1,4 +1,4 @@
-# Writing documentation
+# Documentation
 
 Documentation used to require learning reStructuredText (sometimes referred to
 as reST / rST), but today we have great choices for documentation in markdown,

--- a/docs/guides/pytest.md
+++ b/docs/guides/pytest.md
@@ -1,4 +1,4 @@
-# Testing with pytest
+# Testing
 
 Tests are crucial to writing reliable software. A good test suite allows you to:
 


### PR DESCRIPTION
Making titles a bit simpler.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--841.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->