### PR TITLE
chore: update build-and-inspect-python-package to v3.0.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
 
   publish:
     name: Publish

--- a/docs/guides/gha_pure.md
+++ b/docs/guides/gha_pure.md
@@ -111,7 +111,7 @@ pre-upload checks & nice GitHub summaries.
 ```yaml
 steps:
   - uses: actions/checkout@v7
-  - uses: hynek/build-and-inspect-python-package@v2
+  - uses: hynek/build-and-inspect-python-package@v3.0.1
 ```
 
 The artifact it produces is named `Packages`, so that's what you need to use
@@ -215,7 +215,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@v3.0.1
 
   publish:
     needs: [dist]
@@ -266,7 +266,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@v3.0.1
 
   publish:
     needs: [dist]

--- a/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type!='compiled' %}cd.yml{% endif %}
+++ b/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type!='compiled' %}cd.yml{% endif %}
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@v3.0.1
 
   publish:
     needs: [dist]


### PR DESCRIPTION
Prompted by https://github.com/pypa/hatch/issues/2292.

:robot: _AI text below_ :robot:

Updates `hynek/build-and-inspect-python-package` to v3.0.1 in the template, the `gha_pure` guide, and this repo's own `cd.yml` (SHA pin `2abe76d`).

v3 stopped force-pushing the moving `v3`/`v3.0` tags, so the docs and template now use the full version tag. The `gha_bump` nox session selects candidate tags by dot count, so it continues to find new releases with the longer version; verified against the live API. Actions that still use moving major tags are unaffected.

There are no input, output, or artifact-name changes in v3.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--848.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->