### PR TITLE
chore: use actions/attest instead of the wrapper action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
           path: dist
 
       - name: Generate artifact attestation for sdist and wheel
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: "dist/*"
 

--- a/docs/guides/gha_pure.md
+++ b/docs/guides/gha_pure.md
@@ -142,7 +142,7 @@ publish:
         path: dist
 
     - name: Generate artifact attestation for sdist and wheel
-      uses: actions/attest-build-provenance@v4
+      uses: actions/attest@v4
       with:
         subject-path: "dist/*"
 
@@ -234,7 +234,7 @@ jobs:
           path: dist
 
       - name: Generate artifact attestation for sdist and wheel
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-path: "dist/*"
 

--- a/docs/guides/gha_wheels.md
+++ b/docs/guides/gha_wheels.md
@@ -179,7 +179,7 @@ upload_all:
         merge-multiple: true
 
     - name: Generate artifact attestations
-      uses: actions/attest-build-provenance@v4
+      uses: actions/attest@v4
       with:
         subject-path: "dist/*"
 

--- a/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type!='compiled' %}cd.yml{% endif %}
+++ b/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type!='compiled' %}cd.yml{% endif %}
@@ -54,7 +54,7 @@ jobs:
           path: dist
 
       - name: Generate artifact attestation for sdist and wheel
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-path: "dist/*"
 

--- a/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type=='compiled' %}cd.yml{% endif %}
+++ b/{{cookiecutter.project_name}}/.github/workflows/{% if cookiecutter.__type=='compiled' %}cd.yml{% endif %}
@@ -93,7 +93,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate artifact attestations
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-path: "dist/*"
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`actions/attest-build-provenance` is only a wrapper on `actions/attest` as of v4, and the upstream docs tell new code to use `actions/attest`. This replaces every mention: the repo workflow (SHA-pinned to v4.2.2), both cookiecutter `cd.yml` templates, and the GHA guides.

Inputs are unchanged: `actions/attest` with only `subject-path` generates SLSA build provenance, like the wrapper did. Permissions are unchanged too; the new `artifact-metadata: write` permission is only needed with `push-to-registry`.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--850.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->