### PR TITLE
chore: update webpage pins to 2026.08.14

### DIFF
--- a/docs/guides/repo_review.md
+++ b/docs/guides/repo_review.md
@@ -23,9 +23,9 @@ pipx run 'sp-repo-review[cli]' <path to repo>
   "url_sync": true,
   "deps": [
     "repo-review~=1.2.1",
-    "sp-repo-review==2026.06.18",
+    "sp-repo-review==2026.08.14",
     "validate-pyproject[all]~=0.25.0",
-    "validate-pyproject-schema-store==2026.06.14",
+    "validate-pyproject-schema-store==2026.08.14",
   ]
 }
 :::


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Update the repo-review webapp pins on the docs page to the latest releases:

- `sp-repo-review`: 2026.06.18 → 2026.08.14
- `validate-pyproject-schema-store`: 2026.06.14 → 2026.08.14

`repo-review`, `validate-pyproject`, and the `repo-review-webapp` CDN URL are already at the latest releases.

<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--851.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->