### PR TITLE
ci: check generated templates with development repo-review

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -203,7 +203,7 @@ def diff_files(p1: Path, p2: Path) -> bool:
 @nox.parametrize("vcs", [False, True], ids=["novcs", "vcs"])
 @nox.parametrize("backend", BACKENDS, ids=BACKENDS)
 def lint(session: nox.Session, backend: str, vcs: bool, docs: Docs) -> None:
-    session.install("cookiecutter", "prek")
+    session.install(f"{DIR}[cli]", "cookiecutter", "prek")
 
     tmp_dir = session.create_tmp()
     session.cd(tmp_dir)
@@ -217,6 +217,7 @@ def lint(session: nox.Session, backend: str, vcs: bool, docs: Docs) -> None:
         "--hook-stage=manual",
         "--show-diff-on-failure",
     )
+    session.run("sp-repo-review", ".")
 
 
 @nox.session(default=False)


### PR DESCRIPTION
The generated-template lint session currently runs prek without checking the output against sp-repo-review. Install the development package from this checkout and run `sp-repo-review .` inside each generated project, so review failures fail the existing CI lint job.

Fixes #721.

Validation on macOS with Python 3.12:

- `uvx nox -s rr_lint` passed.
- `uvx nox -s lint` passed all 60 combinations: 10 backends, VCS enabled/disabled, and three documentation engines.
- `git diff --check` passed.


<!-- readthedocs-preview scientific-python-cookie start -->
----
📚 Documentation preview 📚: https://scientific-python-cookie--856.org.readthedocs.build/

<!-- readthedocs-preview scientific-python-cookie end -->